### PR TITLE
Travis fix that will populate properties for version and some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+before_install:
+   - mvn resources:resources

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/UserAgent.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/UserAgent.java
@@ -1,15 +1,10 @@
 package com.microsoft.bot.connector;
 
 import com.microsoft.bot.connector.implementation.ConnectorClientImpl;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static java.util.stream.Collectors.joining;
 
 /**
  * Retrieve the User Agent string that BotBuilder uses
@@ -19,17 +14,11 @@ import static java.util.stream.Collectors.joining;
  * <p>
  */
 public class UserAgent {
-    private static Object synclock = new Object();
-    private static Map<String, String> middlewareSet = new ConcurrentHashMap<String, String>();
-    private static Map<String, String> storageSet = new ConcurrentHashMap<String, String>();
-    private static String luisVersion = null;
-    private static String qnaVersion = null;
-    private static boolean hasChanged = true;
-    private static String cache_value = null;
 
 
     // os/java and botbuilder will never change - static initialize once
     private static String os_java_botbuilder_cache;
+
     static {
         String build_version;
         final Properties properties = new Properties();
@@ -55,101 +44,9 @@ public class UserAgent {
 
     /**
      * Retrieve the user agent string for BotBuilder.
-     *
      */
     public static String value() {
-
-        synchronized (synclock) {
-            if (!hasChanged) {
-                return cache_value;
-            }
-        }
-
-
-        StringBuilder val = new StringBuilder();
-        val.append(os_java_botbuilder_cache);
-        if (middlewareSet.size() > 0) {
-            String middleware = middlewareSet.values().stream().collect(joining(";"));
-            val.append(String.format(" Middleware(%s)", middleware));
-        }
-        if (storageSet.size() > 0) {
-            String storage = storageSet.values().stream().collect(joining(";"));
-            val.append(String.format(" Storage(%s)", storage));
-        }
-        if (!StringUtils.isBlank(luisVersion))
-            val.append(String.format(" LUIS(%s)", luisVersion));
-        if (!StringUtils.isBlank(qnaVersion))
-            val.append(String.format(" Qna(%s)", qnaVersion));
-        synchronized (synclock) {
-            cache_value = val.toString();
-            hasChanged = false;
-        }
-        return cache_value;
+        return os_java_botbuilder_cache;
     }
 
-    /**
-     * Add a Middleware component to the agent string.
-     * Idempotent and last component wins.  For example, if two versions of a component registers with two different
-     * versions, (1) only one component will be in the agent string, (2) the first version that registers will be
-     * the one reported.
-     *
-     * @param middlewareName    Friendly name of the Middleware component
-     * @param middlewareVersion Component version in form v1.1.0
-     */
-    public static void AddMiddlewareComponent(String middlewareName, String middlewareVersion) {
-        synchronized (synclock) {
-            hasChanged = true;
-            middlewareSet.put(middlewareName, middlewareName + "/" + middlewareVersion);
-        }
-    }
-
-    /**
-     * Add a Storage component to the agent string.
-     * Idempotent and last component wins.  For example, if two versions of a component registers with two different
-     * versions, (1) only one component will be in the agent string, (2) the first version that registers will be
-     * the one reported.
-     *
-     * @param storageName    Friendly name of the Storage component
-     * @param storageVersion Component version in the form v1.1.0
-     */
-    public static void AddStorageComponent(String storageName, String storageVersion) {
-        synchronized (synclock) {
-            hasChanged = true;
-            storageSet.put(storageName, storageName + "/" + storageVersion);
-        }
-    }
-
-    /**
-     * Add a LUIS version to the agent string.
-     * Idempotent and last call wins.  For example, if two versions of a component registers with two different
-     * versions, (1) only one LUIS component will be in the agent string, (2) the first version that registers will be
-     * the one reported.
-     *
-     * @param version LUIS component version in the form v1.1.0
-     */
-    public static void SetLuisVersion(String version) {
-        if (StringUtils.isBlank(luisVersion)) {
-            synchronized (synclock) {
-                hasChanged = true;
-                luisVersion = version;
-            }
-        }
-    }
-
-    /**
-     * Add a Qna version to the agent string.
-     * Idempotent and last call wins.  For example, if two versions of a component registers with two different
-     * versions, (1) only one Qna component will be in the agent string, (2) the first version that registers will be
-     * the one reported.
-     *
-     * @param version Qna component version in the form v1.1.0
-     */
-    public static void SetQnaVersion(String version) {
-        if (StringUtils.isBlank(qnaVersion)) {
-            synchronized (synclock) {
-                hasChanged = true;
-                qnaVersion = version;
-            }
-        }
-    }
 }

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/UserAgent.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/UserAgent.java
@@ -1,0 +1,155 @@
+package com.microsoft.bot.connector;
+
+import com.microsoft.bot.connector.implementation.ConnectorClientImpl;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Retrieve the User Agent string that BotBuilder uses
+ * <p>
+ * Conforms to spec:
+ * https://github.com/Microsoft/botbuilder-dotnet/blob/d342cd66d159a023ac435aec0fdf791f93118f5f/doc/UserAgents.md
+ * <p>
+ */
+public class UserAgent {
+    private static Object synclock = new Object();
+    private static Map<String, String> middlewareSet = new ConcurrentHashMap<String, String>();
+    private static Map<String, String> storageSet = new ConcurrentHashMap<String, String>();
+    private static String luisVersion = null;
+    private static String qnaVersion = null;
+    private static boolean hasChanged = true;
+    private static String cache_value = null;
+
+
+    // os/java and botbuilder will never change - static initialize once
+    private static String os_java_botbuilder_cache;
+    static {
+        String build_version;
+        final Properties properties = new Properties();
+        try {
+            InputStream propStream = ConnectorClientImpl.class.getClassLoader().getResourceAsStream("project.properties");
+            properties.load(propStream);
+            build_version = properties.getProperty("version");
+        } catch (IOException e) {
+            e.printStackTrace();
+            build_version = "4.0.0";
+        }
+        String os_version = System.getProperty("os.name");
+        String java_version = System.getProperty("java.version");
+        os_java_botbuilder_cache = String.format("BotBuilder/%s (JVM %s; %s)", build_version, java_version, os_version);
+    }
+
+    /**
+     * Private Constructor - Static Object
+     */
+    private UserAgent() {
+
+    }
+
+    /**
+     * Retrieve the user agent string for BotBuilder.
+     *
+     */
+    public static String value() {
+
+        synchronized (synclock) {
+            if (!hasChanged) {
+                return cache_value;
+            }
+        }
+
+
+        StringBuilder val = new StringBuilder();
+        val.append(os_java_botbuilder_cache);
+        if (middlewareSet.size() > 0) {
+            String middleware = middlewareSet.values().stream().collect(joining(";"));
+            val.append(String.format(" Middleware(%s)", middleware));
+        }
+        if (storageSet.size() > 0) {
+            String storage = storageSet.values().stream().collect(joining(";"));
+            val.append(String.format(" Storage(%s)", storage));
+        }
+        if (!StringUtils.isBlank(luisVersion))
+            val.append(String.format(" LUIS(%s)", luisVersion));
+        if (!StringUtils.isBlank(qnaVersion))
+            val.append(String.format(" Qna(%s)", qnaVersion));
+        synchronized (synclock) {
+            cache_value = val.toString();
+            hasChanged = false;
+        }
+        return cache_value;
+    }
+
+    /**
+     * Add a Middleware component to the agent string.
+     * Idempotent and last component wins.  For example, if two versions of a component registers with two different
+     * versions, (1) only one component will be in the agent string, (2) the first version that registers will be
+     * the one reported.
+     *
+     * @param middlewareName    Friendly name of the Middleware component
+     * @param middlewareVersion Component version in form v1.1.0
+     */
+    public static void AddMiddlewareComponent(String middlewareName, String middlewareVersion) {
+        synchronized (synclock) {
+            hasChanged = true;
+            middlewareSet.put(middlewareName, middlewareName + "/" + middlewareVersion);
+        }
+    }
+
+    /**
+     * Add a Storage component to the agent string.
+     * Idempotent and last component wins.  For example, if two versions of a component registers with two different
+     * versions, (1) only one component will be in the agent string, (2) the first version that registers will be
+     * the one reported.
+     *
+     * @param storageName    Friendly name of the Storage component
+     * @param storageVersion Component version in the form v1.1.0
+     */
+    public static void AddStorageComponent(String storageName, String storageVersion) {
+        synchronized (synclock) {
+            hasChanged = true;
+            storageSet.put(storageName, storageName + "/" + storageVersion);
+        }
+    }
+
+    /**
+     * Add a LUIS version to the agent string.
+     * Idempotent and last call wins.  For example, if two versions of a component registers with two different
+     * versions, (1) only one LUIS component will be in the agent string, (2) the first version that registers will be
+     * the one reported.
+     *
+     * @param version LUIS component version in the form v1.1.0
+     */
+    public static void SetLuisVersion(String version) {
+        if (StringUtils.isBlank(luisVersion)) {
+            synchronized (synclock) {
+                hasChanged = true;
+                luisVersion = version;
+            }
+        }
+    }
+
+    /**
+     * Add a Qna version to the agent string.
+     * Idempotent and last call wins.  For example, if two versions of a component registers with two different
+     * versions, (1) only one Qna component will be in the agent string, (2) the first version that registers will be
+     * the one reported.
+     *
+     * @param version Qna component version in the form v1.1.0
+     */
+    public static void SetQnaVersion(String version) {
+        if (StringUtils.isBlank(qnaVersion)) {
+            synchronized (synclock) {
+                hasChanged = true;
+                qnaVersion = version;
+            }
+        }
+    }
+}

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/UserAgentTest.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/UserAgentTest.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 public class UserAgentTest {
     /**
-     * BotBuilder/4.0.0-SNAPSHOT (JVM 1.8.0_172; Windows 10) Middleware(MyMiddleware/v1.0.0) Storage(MyStorage/v1.10.0) LUIS(v1.0.0) Qna(v1.0.0)
+     * BotBuilder/4.0.0-SNAPSHOT (JVM 1.8.0_172; Windows 10)
      * https://github.com/Microsoft/botbuilder-dotnet/blob/d342cd66d159a023ac435aec0fdf791f93118f5f/doc/UserAgents.md
      */
     @Test
@@ -16,48 +16,6 @@ public class UserAgentTest {
         Assert.assertTrue(Pattern.matches("^BotBuilder/\\S*\\s\\(JVM.*$", userAgent));
         Assert.assertFalse(userAgent.contains("{"));
         Assert.assertFalse(userAgent.contains("}"));
-    }
-
-    @Test
-    public void AddMiddlewareComponent() {
-        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
-        String userAgent = UserAgent.value();
-        Assert.assertTrue(userAgent.contains("MyMiddleware"));
-    }
-    @Test
-    public void AddMultipleMiddlewareComponent() {
-        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
-        UserAgent.AddMiddlewareComponent("MyMiddleware1", "v1.0.0");
-        UserAgent.AddMiddlewareComponent("MyMiddleware2", "v1.0.0");
-        UserAgent.AddMiddlewareComponent("MyMiddleware3", "v1.0.0");
-        String userAgent = UserAgent.value();
-        Assert.assertTrue(userAgent.contains("MyMiddleware") );
-        Assert.assertTrue(userAgent.contains("MyMiddleware1") );
-        Assert.assertTrue(userAgent.contains("MyMiddleware2") );
-        Assert.assertTrue(userAgent.contains("MyMiddleware3") );
-    }
-
-    @Test
-    public void OverrideMultipleMiddlewareComponentVersion() {
-        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
-        UserAgent.AddMiddlewareComponent("MyMiddleware", "v2.0.0");
-        String userAgent = UserAgent.value();
-        Assert.assertTrue(userAgent.contains("MyMiddleware/v2.0.0") );
-        // Attempt override
-        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
-        Assert.assertTrue(userAgent.contains("MyMiddleware/v2.0.0") );
-    }
-    @Test
-    public void AddMiddlewareStorageLuisQna() {
-        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
-        UserAgent.AddStorageComponent("MyStorage", "v1.10.0");
-        UserAgent.SetLuisVersion("v1.0.0");
-        UserAgent.SetQnaVersion("v1.0.0");
-        String userAgent = UserAgent.value();
-        Assert.assertTrue(userAgent.contains("MyMiddleware/v1.0.0"));
-        Assert.assertTrue(userAgent.contains("MyStorage/v1.10.0"));
-        Assert.assertTrue(userAgent.contains("LUIS(v1.0.0)"));
-        Assert.assertTrue(userAgent.contains("Qna(v1.0.0)"));
     }
 
 }

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/UserAgentTest.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/UserAgentTest.java
@@ -1,0 +1,63 @@
+package com.microsoft.bot.connector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+public class UserAgentTest {
+    /**
+     * BotBuilder/4.0.0-SNAPSHOT (JVM 1.8.0_172; Windows 10) Middleware(MyMiddleware/v1.0.0) Storage(MyStorage/v1.10.0) LUIS(v1.0.0) Qna(v1.0.0)
+     * https://github.com/Microsoft/botbuilder-dotnet/blob/d342cd66d159a023ac435aec0fdf791f93118f5f/doc/UserAgents.md
+     */
+    @Test
+    public void GetAgentString() {
+        String userAgent = UserAgent.value();
+        Assert.assertTrue(Pattern.matches("^BotBuilder/\\S*\\s\\(JVM.*$", userAgent));
+        Assert.assertFalse(userAgent.contains("{"));
+        Assert.assertFalse(userAgent.contains("}"));
+    }
+
+    @Test
+    public void AddMiddlewareComponent() {
+        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
+        String userAgent = UserAgent.value();
+        Assert.assertTrue(userAgent.contains("MyMiddleware"));
+    }
+    @Test
+    public void AddMultipleMiddlewareComponent() {
+        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
+        UserAgent.AddMiddlewareComponent("MyMiddleware1", "v1.0.0");
+        UserAgent.AddMiddlewareComponent("MyMiddleware2", "v1.0.0");
+        UserAgent.AddMiddlewareComponent("MyMiddleware3", "v1.0.0");
+        String userAgent = UserAgent.value();
+        Assert.assertTrue(userAgent.contains("MyMiddleware") );
+        Assert.assertTrue(userAgent.contains("MyMiddleware1") );
+        Assert.assertTrue(userAgent.contains("MyMiddleware2") );
+        Assert.assertTrue(userAgent.contains("MyMiddleware3") );
+    }
+
+    @Test
+    public void OverrideMultipleMiddlewareComponentVersion() {
+        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
+        UserAgent.AddMiddlewareComponent("MyMiddleware", "v2.0.0");
+        String userAgent = UserAgent.value();
+        Assert.assertTrue(userAgent.contains("MyMiddleware/v2.0.0") );
+        // Attempt override
+        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
+        Assert.assertTrue(userAgent.contains("MyMiddleware/v2.0.0") );
+    }
+    @Test
+    public void AddMiddlewareStorageLuisQna() {
+        UserAgent.AddMiddlewareComponent("MyMiddleware", "v1.0.0");
+        UserAgent.AddStorageComponent("MyStorage", "v1.10.0");
+        UserAgent.SetLuisVersion("v1.0.0");
+        UserAgent.SetQnaVersion("v1.0.0");
+        String userAgent = UserAgent.value();
+        Assert.assertTrue(userAgent.contains("MyMiddleware/v1.0.0"));
+        Assert.assertTrue(userAgent.contains("MyStorage/v1.10.0"));
+        Assert.assertTrue(userAgent.contains("LUIS(v1.0.0)"));
+        Assert.assertTrue(userAgent.contains("Qna(v1.0.0)"));
+    }
+
+}


### PR DESCRIPTION
This is a small fix to the travis build which will run maven and give us the build version at runtime (simple, right?).

Here's the doc reference below, but essentially the way this works is you run: "mvn resources:resources" and it will magically populate a properties file which we load and cache the version for the user agent string.

http://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html

And add some tests.  Support the other component stuff if we're going to go that route.  Easy enough to pull.  Component stuff is not placed in their by default.
