### PR TITLE
Fixed a bug related to trustHostNames that could cause 401 response

### DIFF
--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/MicrosoftAppCredentials.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/MicrosoftAppCredentials.java
@@ -125,7 +125,7 @@ public class MicrosoftAppCredentials implements ServiceClientCredentials {
     }
 
     public static void trustServiceUrl(URL serviceUrl, LocalDateTime expirationTime) {
-        trustHostNames.putIfAbsent(serviceUrl.getHost(), expirationTime);
+        trustHostNames.put(serviceUrl.getHost(), expirationTime);
     }
 
     public static boolean isTrustedServiceUrl(String serviceUrl) {
@@ -148,6 +148,6 @@ public class MicrosoftAppCredentials implements ServiceClientCredentials {
     private static ConcurrentMap<String, LocalDateTime> trustHostNames = new ConcurrentHashMap<>();
 
     static {
-        trustHostNames.putIfAbsent("state.botframework.com", LocalDateTime.MAX);
+        trustHostNames.put("state.botframework.com", LocalDateTime.MAX);
     }
 }


### PR DESCRIPTION
Hi,

This fix is related to an [issue I have opened ](https://github.com/Microsoft/botbuilder-java/issues/55).
Using trustHostNames.**putIfAbsent** in the _trustServiceUrl_ method, prevents the expiration time of the URL host to ever get updated. 
So after a day will pass, the URL host will no longer be trusted even if trustServiceUrl is called again.

This bug caused our bot to start receiving 401 response after a day it was running because that MicrosoftAppCredentialsInterceptor.intercept received _false_ from MicrosoftAppCredentials.isTrustedServiceUrl so it didn't add the Authorization header like it was supposed to.

The change I made also matched how MicrosoftAppCredentials works in the C# version [as you can see here](https://github.com/Microsoft/botbuilder-dotnet/blob/692e4e0afc34c285d317d4caecb34dceccbef5d3/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs) the _TrustServiceUrl_ method always updates the expiration time of the URL host. 