### PR TITLE
Use non-blocking queue in TranscriptLoggerMiddleware

### DIFF
--- a/libraries/botbuilder/src/main/java/com/microsoft/bot/builder/TranscriptLoggerMiddleware.java
+++ b/libraries/botbuilder/src/main/java/com/microsoft/bot/builder/TranscriptLoggerMiddleware.java
@@ -17,7 +17,8 @@ import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 
 /**
@@ -36,7 +37,7 @@ public class TranscriptLoggerMiddleware implements Middleware {
     private TranscriptLogger logger;
     private static final Logger log4j = LogManager.getLogger("BotFx");
 
-    private LinkedList<Activity> transcript = new LinkedList<Activity>();
+    private Queue<Activity> transcript = new ConcurrentLinkedQueue<Activity>();
 
     /**
      * Initializes a new instance of the <see cref="TranscriptLoggerMiddleware"/> class.
@@ -178,12 +179,10 @@ public class TranscriptLoggerMiddleware implements Middleware {
 
 
     private void LogActivity(Activity activity) {
-        synchronized (transcript) {
-            if (activity.timestamp() == null) {
-                activity.withTimestamp(DateTime.now(DateTimeZone.UTC));
-            }
-            transcript.offer(activity);
+        if (activity.timestamp() == null) {
+            activity.withTimestamp(DateTime.now(DateTimeZone.UTC));
         }
+        transcript.offer(activity);
     }
 
 }


### PR DESCRIPTION
Hi!
I'm starting to play with the Bot Builder, and I noticed that `synchronized` block in the transcript logger... wouldn't it be better to use a non-blocking queue instead?

Oh, and thank you for providing a Java version 😊 