### PR TITLE
Added functionality to fetch team members.

### DIFF
--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/Conversations.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/Conversations.java
@@ -16,6 +16,7 @@ import com.microsoft.bot.schema.models.ChannelAccount;
 import com.microsoft.bot.schema.models.ConversationParameters;
 import com.microsoft.bot.schema.models.ConversationResourceResponse;
 import com.microsoft.bot.schema.models.ConversationsResult;
+import com.microsoft.bot.schema.models.TeammateAccount;
 import com.microsoft.bot.connector.models.ErrorResponseException;
 import com.microsoft.bot.schema.models.ResourceResponse;
 import com.microsoft.rest.ServiceCallback;
@@ -491,6 +492,19 @@ public interface Conversations {
     List<ChannelAccount> getConversationMembers(String conversationId);
 
     /**
+     * GetTeamsConversationMembers.
+     * Enumerate the members of a team.
+     This REST API takes a TeamId and returns an array of TeammateAccount objects representing the members of the team.
+     *
+     * @param teamId Team ID
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @throws ErrorResponseException thrown if the request is rejected by server
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the List&lt;TeammateAccount&gt; object if successful.
+     */
+    List<TeammateAccount> getTeamsConversationMembers(String teamId);
+
+    /**
      * GetConversationMembers.
      * Enumerate the members of a converstion.
      This REST API takes a ConversationId and returns an array of ChannelAccount objects representing the members of the conversation.
@@ -514,6 +528,17 @@ public interface Conversations {
     Observable<List<ChannelAccount>> getConversationMembersAsync(String conversationId);
 
     /**
+     * GetTeamsConversationMembers.
+     * Enumerate the members of a team.
+     This REST API takes a TeamId and returns an array of TeammateAccount objects representing the members of the team.
+     *
+     * @param teamId Team ID
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;TeammateAccount&gt; object
+     */
+    Observable<List<TeammateAccount>> getTeamsConversationMembersAsync(String teamId);
+
+    /**
      * GetConversationMembers.
      * Enumerate the members of a converstion.
      This REST API takes a ConversationId and returns an array of ChannelAccount objects representing the members of the conversation.
@@ -523,6 +548,17 @@ public interface Conversations {
      * @return the observable to the List&lt;ChannelAccount&gt; object
      */
     Observable<ServiceResponse<List<ChannelAccount>>> getConversationMembersWithServiceResponseAsync(String conversationId);
+
+    /**
+     * GetTeamsConversationMembers.
+     * Enumerate the members of a team.
+     This REST API takes a teamId and returns an array of TeammateAccount objects representing the members of the team.
+     *
+     * @param teamId Team ID
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;TeammateAccount&gt; object
+     */
+    Observable<ServiceResponse<List<TeammateAccount>>> getTeamsConversationMembersWithServiceResponseAsync(String teamId);
 
     /**
      * DeleteConversationMember.

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/implementation/ConversationsImpl.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/implementation/ConversationsImpl.java
@@ -18,6 +18,7 @@ import com.microsoft.bot.schema.models.ChannelAccount;
 import com.microsoft.bot.schema.models.ConversationParameters;
 import com.microsoft.bot.schema.models.ConversationResourceResponse;
 import com.microsoft.bot.schema.models.ConversationsResult;
+import com.microsoft.bot.schema.models.TeammateAccount;
 import com.microsoft.bot.connector.models.ErrorResponseException;
 import com.microsoft.bot.schema.models.ResourceResponse;
 import com.microsoft.rest.ServiceCallback;
@@ -97,6 +98,10 @@ public class ConversationsImpl implements Conversations {
         @GET("v3/conversations/{conversationId}/members")
         Observable<Response<ResponseBody>> getConversationMembers(@Path("conversationId") String conversationId, @Header("accept-language") String acceptLanguage, @Header("User-Agent") String userAgent);
 
+        @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.bot.schema.Conversations getTeamConversationMembers" })
+        @GET("v3/conversations/{teamId}/members")
+        Observable<Response<ResponseBody>> getTeamConversationMembers(@Path("teamId") String teamId, @Header("accept-language") String acceptLanguage, @Header("User-Agent") String userAgent);
+
         @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.bot.schema.Conversations deleteConversationMember" })
         @HTTP(path = "v3/conversations/{conversationId}/members/{memberId}", method = "DELETE", hasBody = true)
         Observable<Response<ResponseBody>> deleteConversationMember(@Path("conversationId") String conversationId, @Path("memberId") String memberId, @Header("accept-language") String acceptLanguage, @Header("User-Agent") String userAgent);
@@ -108,7 +113,6 @@ public class ConversationsImpl implements Conversations {
         @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.bot.schema.Conversations uploadAttachment" })
         @POST("v3/conversations/{conversationId}/attachments")
         Observable<Response<ResponseBody>> uploadAttachment(@Path("conversationId") String conversationId, @Body AttachmentData attachmentUpload, @Header("accept-language") String acceptLanguage, @Header("User-Agent") String userAgent);
-
     }
 
     public static <T> CompletableFuture<List<T>> completableFutureFromObservable(Observable<T> observable) {
@@ -847,6 +851,21 @@ public class ConversationsImpl implements Conversations {
     }
 
     /**
+     * GetTeamsConversationMembers.
+     * Enumerate the members of a team.
+     This REST API takes a TeamId and returns an array of TeammateAccount objects representing the members of the team.
+     *
+     * @param teamId Team ID
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @throws ErrorResponseException thrown if the request is rejected by server
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the List&lt;TeammateAccount&gt; object if successful.
+     */
+    public List<TeammateAccount> getTeamsConversationMembers(String teamId) {
+        return getTeamsConversationMembersWithServiceResponseAsync(teamId).toBlocking().single().body();
+    }
+
+    /**
      * GetConversationMembers.
      * Enumerate the members of a converstion.
      This REST API takes a ConversationId and returns an array of ChannelAccount objects representing the members of the conversation.
@@ -879,6 +898,24 @@ public class ConversationsImpl implements Conversations {
     }
 
     /**
+     * GetTeamsConversationMembers.
+     * Enumerate the members of a team.
+     This REST API takes a TeamId and returns an array of TeammateAccount objects representing the members of the team.
+     *
+     * @param teamId Team ID
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;TeammateAccount&gt; object
+     */
+    public Observable<List<TeammateAccount>> getTeamsConversationMembersAsync(String teamId) {
+        return getTeamsConversationMembersWithServiceResponseAsync(teamId).map(new Func1<ServiceResponse<List<TeammateAccount>>, List<TeammateAccount>>() {
+            @Override
+            public List<TeammateAccount> call(ServiceResponse<List<TeammateAccount>> response) {
+                return response.body();
+            }
+        });
+    }
+
+    /**
      * GetConversationMembers.
      * Enumerate the members of a converstion.
      This REST API takes a ConversationId and returns an array of ChannelAccount objects representing the members of the conversation.
@@ -905,9 +942,43 @@ public class ConversationsImpl implements Conversations {
             });
     }
 
+    /**
+     * GetTeamsConversationMembers.
+     * Enumerate the members of a team.
+     This REST API takes a TeamId and returns an array of TeammateAccount objects representing the members of the team.
+     *
+     * @param teamId Team ID
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;TeammateAccount&gt; object
+     */
+    public Observable<ServiceResponse<List<TeammateAccount>>> getTeamsConversationMembersWithServiceResponseAsync(String teamId) {
+        if (teamId == null) {
+            throw new IllegalArgumentException("Parameter teamId is required and cannot be null.");
+        }
+        return service.getTeamConversationMembers(teamId, this.client.acceptLanguage(), this.client.userAgent())
+                .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<TeammateAccount>>>>() {
+                    @Override
+                    public Observable<ServiceResponse<List<TeammateAccount>>> call(Response<ResponseBody> response) {
+                        try {
+                            ServiceResponse<List<TeammateAccount>> clientResponse = getTeamsConversationMembersDelegate(response);
+                            return Observable.just(clientResponse);
+                        } catch (Throwable t) {
+                            return Observable.error(t);
+                        }
+                    }
+                });
+    }
+
     private ServiceResponse<List<ChannelAccount>> getConversationMembersDelegate(Response<ResponseBody> response) throws ErrorResponseException, IOException, IllegalArgumentException {
         return this.client.restClient().responseBuilderFactory().<List<ChannelAccount>, ErrorResponseException>newInstance(this.client.serializerAdapter())
                 .register(200, new TypeToken<List<ChannelAccount>>() { }.getType())
+                .registerError(ErrorResponseException.class)
+                .build(response);
+    }
+
+    private ServiceResponse<List<TeammateAccount>> getTeamsConversationMembersDelegate(Response<ResponseBody> response) throws ErrorResponseException, IOException, IllegalArgumentException {
+        return this.client.restClient().responseBuilderFactory().<List<TeammateAccount>, ErrorResponseException>newInstance(this.client.serializerAdapter())
+                .register(200, new TypeToken<List<TeammateAccount>>() { }.getType())
                 .registerError(ErrorResponseException.class)
                 .build(response);
     }

--- a/libraries/botbuilder-schema/src/main/java/com/microsoft/bot/schema/models/TeammateAccount.java
+++ b/libraries/botbuilder-schema/src/main/java/com/microsoft/bot/schema/models/TeammateAccount.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ *
+ */
+
+package com.microsoft.bot.schema.models;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Teammate account information needed to fetch team members.
+ */
+public class TeammateAccount {
+    /**
+     * Channel id for the user on this channel (Example: joe@smith.com,
+     * or @joesmith or 123456).
+     */
+    @JsonProperty(value = "id")
+    private String id;
+
+    @JsonProperty(value = "objectId")
+    private String objectId;
+
+    @JsonProperty(value = "givenName")
+    private String givenName;
+
+    @JsonProperty(value = "surname")
+    private String surname;
+
+    @JsonProperty(value = "email")
+    private String email;
+
+    @JsonProperty(value = "userPrincipalName")
+    private String userPrincipalName;
+
+    /**
+     * Get the id value.
+     *
+     * @return the id value
+     */
+    public String id() {
+        return this.id;
+    }
+
+    /**
+     * Set the id value.
+     *
+     * @param id the id value to set
+     * @return the TeammateAccount object itself.
+     */
+    public TeammateAccount withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Get the objectId value.
+     *
+     * @return the objectId value
+     */
+    public String objectId() {
+        return this.objectId;
+    }
+
+    /**
+     * Set the objectId value.
+     *
+     * @param objectId the name value to set
+     * @return the TeammateAccount object itself.
+     */
+    public TeammateAccount withObjectId(String objectId) {
+        this.objectId = objectId;
+        return this;
+    }
+
+    /**
+     * Get the givenName value.
+     *
+     * @return the givenName value
+     */
+    public String givenName() {
+        return this.givenName;
+    }
+
+    /**
+     * Set the givenName value.
+     *
+     * @param givenName the name value to set
+     * @return the TeammateAccount object itself.
+     */
+    public TeammateAccount withGivenName(String givenName) {
+        this.givenName = givenName;
+        return this;
+    }
+
+    /**
+     * Get the surname value.
+     *
+     * @return the surname value
+     */
+    public String surname() {
+        return this.givenName;
+    }
+
+    /**
+     * Set the surname value.
+     *
+     * @param surname the name value to set
+     * @return the TeammateAccount object itself.
+     */
+    public TeammateAccount withSurname(String surname) {
+        this.surname = surname;
+        return this;
+    }
+
+    /**
+     * Get the email value.
+     *
+     * @return the email value
+     */
+    public String email() {
+        return this.email;
+    }
+
+    /**
+     * Set the email value.
+     *
+     * @param email the name value to set
+     * @return the TeammateAccount object itself.
+     */
+    public TeammateAccount withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    /**
+     * Get the userPrincipalName value.
+     *
+     * @return the userPrincipalName value
+     */
+    public String userPrincipalName() {
+        return this.userPrincipalName;
+    }
+
+    /**
+     * Set the email value.
+     *
+     * @param userPrincipalName the name value to set
+     * @return the TeammateAccount object itself.
+     */
+    public TeammateAccount withUserPrincipalName(String userPrincipalName) {
+        this.userPrincipalName = userPrincipalName;
+        return this;
+    }
+
+
+    /**
+     * Holds the overflow properties that aren't first class
+     * properties in the object.  This allows extensibility
+     * while maintaining the object.
+     *
+     */
+    private HashMap<String, JsonNode> properties = new HashMap<String, JsonNode>();
+
+    /**
+     * Overflow properties.
+     * Properties that are not modelled as first class properties in the object are accessible here.
+     * Note: A property value can be be nested.
+     *
+     * @return A Key-Value map of the properties
+     */
+    @JsonAnyGetter
+    public Map<String, JsonNode> properties() {
+        return this.properties;
+    }
+
+    /**
+     * Set overflow properties.
+     *
+     * @param key Key for the property
+     * @param value JsonNode of value (can be nested)
+     *
+     */
+
+    @JsonAnySetter
+    public void setProperties(String key, JsonNode value) {
+        this.properties.put(key, value);
+    }
+
+
+}


### PR DESCRIPTION
Hi Microsoft team,

First of all thanks for java sdk support for bot framework.

During some test integration I found that the sdk doesn't support getting team members as described on https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-context#fetching-the-team-roster and as well reported as issue https://github.com/Microsoft/botbuilder-java/issues/60.

So I decided to add such functionality.
I haven't added comments to all of self described properties.

Please review and merge, because it would be realy nice to have such functionality.