### PR TITLE
Fix internal proprietary API warning

### DIFF
--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/OAuthTestBase.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/OAuthTestBase.java
@@ -8,7 +8,6 @@ import com.microsoft.bot.connector.base.TestBase;
 import com.microsoft.bot.connector.implementation.ConnectorClientImpl;
 import com.microsoft.bot.schema.models.ChannelAccount;
 import com.microsoft.rest.RestClient;
-import com.sun.jndi.toolkit.url.Uri;
 import okhttp3.Request;
 import org.apache.commons.io.FileSystemUtils;
 


### PR DESCRIPTION
Fixes warning "[WARNING] /D:/a/1/s/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/OAuthTestBase.java:[11,32] com.sun.jndi.toolkit.url.Uri is internal proprietary API and may be removed in a future release".

The import statement removed. Does not appear to be needed.