### PR TITLE
Read Activity Data directly from InputStream

### DIFF
--- a/Generator/generator-botbuilder-java/generators/app/templates/app.java
+++ b/Generator/generator-botbuilder-java/generators/app/templates/app.java
@@ -82,25 +82,9 @@ public class App {
             }
         }
 
-        private String getRequestBody(HttpExchange httpExchange) throws IOException {
-            StringBuilder buffer = new StringBuilder();
-            InputStream stream = httpExchange.getRequestBody();
-            int rByte;
-            while ((rByte = stream.read()) != -1) {
-                buffer.append((char)rByte);
-            }
-            stream.close();
-            if (buffer.length() > 0) {
-                return URLDecoder.decode(buffer.toString(), "UTF-8");
-            }
-            return "";
-        }
-
         private Activity getActivity(HttpExchange httpExchange) {
-            try {
-                String body = getRequestBody(httpExchange);
-                LOGGER.log(Level.INFO, body);
-                return objectMapper.readValue(body, Activity.class);
+            try (InputStream is = httpExchange.getRequestBody()) {
+                return objectMapper.readValue(is, Activity.class);
             } catch (Exception ex) {
                 LOGGER.log(Level.WARNING, "Failed to get activity", ex);
                 return null;

--- a/samples/servlet-echo/src/main/java/com/microsoft/bot/sample/servlet/ControllerBase.java
+++ b/samples/servlet-echo/src/main/java/com/microsoft/bot/sample/servlet/ControllerBase.java
@@ -82,22 +82,8 @@ public abstract class ControllerBase extends ServletWithBotConfiguration {
 
     // Creates an Activity object from the request
     private Activity getActivity(HttpServletRequest request) throws IOException {
-        String body = getRequestBody(request);
-        return objectMapper.readValue(body, Activity.class);
-    }
-
-    private String getRequestBody(HttpServletRequest request) throws IOException {
-        StringBuilder buffer = new StringBuilder();
-        try (InputStream stream = request.getInputStream()) {
-            int rByte;
-            while ((rByte = stream.read()) != -1) {
-                buffer.append((char) rByte);
-            }
-            stream.close();
-            if (buffer.length() > 0) {
-                return buffer.toString();
-            }
-            return "";
+        try(InputStream is = request.getInputStream()) {
+            return objectMapper.readValue(is, Activity.class);
         }
     }
 }


### PR DESCRIPTION
The input from the bot is marked as content-type "appliation/json; charset=utf-8"
even if the charset would not be explicitly stated, RFC8259 requires the
encoding to be UTF-8.

The approach to read individual bytes from the inputstream and treat
each byte as a character (ControllerBase.java) or even as url encoded
data (app.java) are just invalid and work by plain luck. If only ascii
input is tested, it most probably mostly works, but fails for all inputs
with high bytes set.

Jackson can decode JSON directly from an inputstream and then does the
right thing, there is no need to manually read the stream.