### PR TITLE
Activity#clone did not consider fields textFormat, attachmentLayout, topicName, listenFor

### DIFF
--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
@@ -372,6 +372,12 @@ public class Activity {
             setExpiration(activity.getExpiration());
             setMembersAdded(ChannelAccount.cloneList(activity.getMembersAdded()));
             setMembersRemoved(ChannelAccount.cloneList(activity.getMembersRemoved()));
+            setTextFormat(activity.getTextFormat());
+            setAttachmentLayout(activity.getAttachmentLayout());
+            setTopicName(activity.getTopicName());
+            if (activity.getListenFor() != null) {
+                setListenFor(new ArrayList<>(activity.getListenFor()));
+            }
         }};
 
         for (Map.Entry<String, JsonNode> entry : activity.getProperties().entrySet()) {


### PR DESCRIPTION
I tested the MemoryTranscriptStore and noticed, that the activities were missing
the textFormat property, that worked correctly when send to the bot. This PR
adds the fields, that are not yet cloned.