### PR TITLE
Align TranscriptLoggerMiddleware implementation with C# version

### DIFF
--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TranscriptLoggerMiddleware.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TranscriptLoggerMiddleware.java
@@ -4,8 +4,7 @@
 package com.microsoft.bot.builder;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ActivityTypes;
 import com.microsoft.bot.schema.ChannelAccount;
@@ -22,17 +21,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * When added, this middleware will log incoming and outgoing activities to a TranscriptStore.
  */
 public class TranscriptLoggerMiddleware implements Middleware {
-    /**
-     * To/From JSON.
-     */
-    private static ObjectMapper mapper;
-
-    static {
-        mapper = new ObjectMapper()
-            .enable(SerializationFeature.INDENT_OUTPUT)
-            .findAndRegisterModules();
-    }
-
     /**
      * The TranscriptLogger to log to.
      */
@@ -78,7 +66,7 @@ public class TranscriptLoggerMiddleware implements Middleware {
             }
 
             if (role == null || StringUtils.isBlank(role.asText())) {
-                context.getActivity().getFrom().getProperties().put("role", mapper.createObjectNode().with("user"));
+                context.getActivity().getFrom().getProperties().put("role", new TextNode("user"));
             }
 
             logActivity(Activity.clone(context.getActivity()));


### PR DESCRIPTION
The TranscriptLoggerMiddleware works on the Emulator, but fails when run
on Azure Infrastructure. This is caused by the invalid modification of
the incoming Activity.

The modifications then create invalid data leading to this JSON fragment
for reply activities:

```javascript
{
    // ...
    "recipient":{
        "properties":{
            "role":{}
        },
        "id":"8d51e790-8bd3-4450-af3d-1741838d1354",
        "role":{}
    },
    // ...
}
```

The role properties should be set to a string, not an object. This
results in a
http 400 status from the bot framework:

```json
{
  "error": {
    "code": "BadSyntax",
    "message": "Invalid or missing Activity in request"
  }
}
```