### PR TITLE
Add access to Microsoft teams information in activity

### DIFF
--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.bot.schema;
 
+import com.microsoft.bot.schema.teams.TeamChannelData;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -1503,5 +1505,45 @@ public class Activity {
         }
 
         return text;
+    }
+
+    /**
+     * Check if this actvity is from microsoft teams.
+     * @return true if the activity is from microsoft teams.
+     */
+    public boolean isTeamsActivity() {
+        return "msteams".equals(channelId);
+    }
+
+    /**
+     * Get unique identifier representing a channel.
+     *
+     * @throws JsonProcessingException when channel data can't be parsed to TeamChannelData
+     * @return Unique identifier representing a channel
+     */
+    public String teamsGetChannelId() throws JsonProcessingException {
+        TeamChannelData teamsChannelData = getChannelData(TeamChannelData.class);
+        String teamsChannelId = teamsChannelData.getTeamsChannelId();
+        if (teamsChannelId == null && teamsChannelData.getChannel() != null) {
+          teamsChannelId = teamsChannelData.getChannel().getId();
+        }
+
+        return teamsChannelId;
+    }
+
+    /**
+     * Get unique identifier representing a team.
+     *
+     * @throws JsonProcessingException when channel data can't be parsed to TeamChannelData
+     * @return Unique identifier representing a team.
+     */
+    public String teamsGetTeamId() throws JsonProcessingException {
+        TeamChannelData teamsChannelData = getChannelData(TeamChannelData.class);
+        String teamId = teamsChannelData.getTeamsTeamId();
+        if (teamId == null && teamsChannelData.getTeam() != null) {
+          teamId = teamsChannelData.getTeam().getId();
+        }
+
+        return teamId;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/ChannelInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/ChannelInfo.java
@@ -57,4 +57,10 @@ public class ChannelInfo {
     this.id = withId;
     this.name = withName;
   }
+
+  /**
+   * Initializes a new instance of the ChannelInfo class.
+   */
+  public ChannelInfo() {
+  }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/ChannelInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/ChannelInfo.java
@@ -1,0 +1,60 @@
+package com.microsoft.bot.schema.teams;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/**
+ * A channel info object which describes the channel.
+*/
+public class ChannelInfo {
+  @JsonProperty(value = "id")
+  private String id;
+
+  /**
+   * name of the channel.
+   */
+  @JsonProperty(value = "name")
+  private String name;
+
+  /**
+   * Get the unique identifier representing a channel.
+   * @return the unique identifier representing a channel.
+   */
+  public final String getId() {
+    return id;
+  }
+
+  /**
+   * Set unique identifier representing a channel.
+   * @param withId the unique identifier representing a channel.
+   */
+  public void setId(String withId) {
+    this.id = withId;
+  }
+
+  /**
+   * Get the name of the channel.
+   * @return name of the channel.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Sets name of the channel.
+   * @param withName the name of the channel.
+   */
+  public void setName(String withName) {
+    this.name = withName;
+  }
+
+  /**
+   * Initializes a new instance of the ChannelInfo class.
+   * @param withId identifier representing a channel.
+   * @param withName Name of the channel.
+   */
+  public ChannelInfo(String withId, String withName) {
+    this.id = withId;
+    this.name = withName;
+  }
+}

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/NotificationInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/NotificationInfo.java
@@ -34,4 +34,10 @@ public class NotificationInfo {
   public NotificationInfo(Boolean withAlert) {
     alert = withAlert;
   }
+
+  /**
+   * A new instance of NotificationInfo.
+   */
+  public NotificationInfo() {
+  }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/NotificationInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/NotificationInfo.java
@@ -1,0 +1,37 @@
+package com.microsoft.bot.schema.teams;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+/**
+ * Specifies if a notification is to be sent for the mentions.
+ */
+public class NotificationInfo {
+  /**
+   * Gets or sets true if notification is to be sent to the user, false.
+   */
+  @JsonProperty(value = "alert")
+  private Boolean alert;
+
+  /**
+   * Getter for alert.
+   * @return return the alter value.
+   */
+  public Boolean getAlert() {
+    return alert;
+  }
+
+  /**
+   * Setter for alert.
+   * @param withAlert the value to set.
+   */
+  public void setAlert(Boolean withAlert) {
+    alert = withAlert;
+  }
+
+  /**
+   * A new instance of NotificationInfo.
+   * @param withAlert alert value to set.
+   */
+  public NotificationInfo(Boolean withAlert) {
+    alert = withAlert;
+  }
+}

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamChannelData.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamChannelData.java
@@ -188,4 +188,10 @@ public class TeamChannelData {
     this.tenant = withTenant;
   }
 
+  /**
+   * A new instance of TeamChannelData.
+   */
+  public TeamChannelData() {
+  }
+
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamChannelData.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamChannelData.java
@@ -1,0 +1,191 @@
+package com.microsoft.bot.schema.teams;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/**
+ * Channel data specific to messages received in Microsoft Teams.
+ */
+public class TeamChannelData {
+  @JsonProperty(value = "teamsChannelId")
+  private String teamsChannelId;
+
+  @JsonProperty(value = "teamsTeamId")
+  private String teamsTeamId;
+
+  @JsonProperty(value = "channel")
+  private ChannelInfo channel;
+
+  /// Gets or sets type of event.
+  @JsonProperty(value = "eventType")
+  private String eventType;
+
+  /// Gets or sets information about the team in which the message was
+  /// sent
+  @JsonProperty(value = "team")
+  private TeamInfo team;
+
+  /// Gets or sets notification settings for the message
+  @JsonProperty(value = "notification")
+  private NotificationInfo notification;
+
+  /// Gets or sets information about the tenant in which the message was
+  /// sent
+  @JsonProperty(value = "tenant")
+  private TenantInfo tenant;
+
+  /**
+   * Get unique identifier representing a channel.
+   * @return Unique identifier representing a channel.
+   */
+  public String getTeamsChannelId() {
+    return teamsChannelId;
+  }
+
+  /**
+   * Set unique identifier representing a channel.
+   * @param withTeamsChannelId Unique identifier representing a channel.
+   */
+  public void setTeamsChannelId(String withTeamsChannelId) {
+    this.teamsChannelId = withTeamsChannelId;
+  }
+
+  /**
+   * Get unique identifier representing a team.
+   * @return Unique identifier representing a team.
+   */
+  public String getTeamsTeamId() {
+    return teamsTeamId;
+  }
+  /**
+   * Set unique identifier representing a team.
+   * @param withTeamsTeamId Unique identifier representing a team.
+   */
+  public void setTeamsTeamId(String withTeamsTeamId) {
+    this.teamsTeamId = withTeamsTeamId;
+  }
+
+  /**
+   * Gets information about the channel in which the message was
+   * sent.
+   *
+   * @return information about the channel in which the message was
+   * sent.
+   */
+  public ChannelInfo getChannel() {
+    return channel;
+  }
+
+  /**
+   * Sets information about the channel in which the message was
+   * sent.
+   *
+   * @param withChannel information about the channel in which the message was
+   * sent.
+   */
+  public void setChannel(ChannelInfo withChannel) {
+    this.channel = withChannel;
+  }
+
+  /**
+   * Gets type of event.
+   *
+   * @return type of event.
+   */
+  public String getEventType() {
+    return eventType;
+  }
+
+  /**
+   * Sets type of event.
+   *
+   * @param withEventType type of event.
+   */
+  public void setEventType(String withEventType) {
+    this.eventType = withEventType;
+  }
+
+  /**
+   *  Gets information about the team in which the message was
+   *  sent.
+   *
+   *  @return information about the team in which the message was
+   *  sent.
+   */
+  public TeamInfo getTeam() {
+    return team;
+  }
+
+  /**
+   *  Sets information about the team in which the message was
+   *  sent.
+   *
+   *  @param withTeam information about the team in which the message was
+   *  sent.
+   */
+  public void setTeam(TeamInfo withTeam) {
+    this.team = withTeam;
+  }
+
+  /**
+   * Gets notification settings for the message.
+   *
+   * @return notification settings for the message.
+   */
+  public NotificationInfo getNotification() {
+    return notification;
+  }
+
+  /**
+   * Sets notification settings for the message.
+   *
+   * @param withNotification settings for the message.
+   */
+  public void setNotification(NotificationInfo withNotification) {
+    this.notification = withNotification;
+  }
+
+  /**
+   * Gets information about the tenant in which the message was.
+   * @return information about the tenant in which the message was.
+   */
+  public TenantInfo getTenant() {
+    return tenant;
+  }
+
+  /**
+   * Sets information about the tenant in which the message was.
+   * @param withTenant information about the tenant in which the message was.
+   */
+  public void setTenant(TenantInfo withTenant) {
+    this.tenant = withTenant;
+  }
+
+  /**
+   * A new instance of TeamChannelData.
+   * @param withTeamsChannelId the channelId in Teams
+   * @param withTeamsTeamId the teamId in Teams
+   * @param withChannel information about the channel in which the message was sent.
+   * @param withEventType type of event.
+   * @param withTeam information about the team in which the message was
+   *  sent.
+   * @param withNotification Notification settings for the message.
+   * @param withTenant Information about the tenant in which the message was.
+   */
+  public TeamChannelData(String withTeamsChannelId,
+                         String withTeamsTeamId,
+                         ChannelInfo withChannel,
+                         String withEventType,
+                         TeamInfo withTeam,
+                         NotificationInfo withNotification,
+                         TenantInfo withTenant) {
+    this.teamsChannelId = withTeamsChannelId;
+    this.teamsTeamId = withTeamsTeamId;
+    this.channel = withChannel;
+    this.eventType = withEventType;
+    this.team = withTeam;
+    this.notification = withNotification;
+    this.tenant = withTenant;
+  }
+
+}

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamInfo.java
@@ -86,4 +86,10 @@ public class TeamInfo {
     this.name = withName;
     this.aadGroupId = withAadGroupId;
   }
+
+  /**
+   * A new instance of TeamInfo.
+   */
+  public TeamInfo() {
+  }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TeamInfo.java
@@ -1,0 +1,89 @@
+package com.microsoft.bot.schema.teams;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Describes a team.
+*/
+public class TeamInfo {
+   /**
+    * Unique identifier representing a team.
+    */
+  @JsonProperty(value = "id")
+  private String id;
+
+   /**
+    * Name of a team.
+    */
+  @JsonProperty(value = "name")
+  private String name;
+
+  /**
+   * Azure Active Directory (AAD) Group Id for the team.
+   *
+   * We don't see this C#, but Teams
+   * definitely sends this to the bot.
+   */
+  @JsonProperty(value = "aadGroupId")
+  private String aadGroupId;
+
+  /**
+   * Get unique identifier representing a team.
+   * @return Unique identifier representing a team.
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Set unique identifier representing a team.
+   * @param withId unique identifier representing a team.
+   */
+  public void setId(String withId) {
+    id = withId;
+  }
+
+  /**
+   * Get the name of the team.
+   * @return get the name of the team.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Set the name of the team.
+   * @param withName name of the team.
+   */
+  public void setName(String withName) {
+    name = withName;
+  }
+
+  /**
+   * Get Azure Active Directory (AAD) Group Id for the team.
+   * @return Azure Active Directory (AAD) Group Id for the team.
+   */
+  public String getAadGroupId() {
+    return aadGroupId;
+  }
+
+  /**
+   * Set Azure Active Directory (AAD) Group Id for the team.
+   * @param withAadGroupId Azure Active Directory (AAD) Group Id for the team
+   */
+  public void setAadGroupId(String withAadGroupId) {
+    this.aadGroupId = withAadGroupId;
+  }
+
+  /**
+   * A new instance of TeamInfo.
+   * @param withId unique identifier representing a team.
+   * @param withName Set the name of the team.
+   * @param withAadGroupId Azure Active Directory (AAD) Group Id for the team
+   */
+  public TeamInfo(String withId, String withName, String withAadGroupId) {
+    this.id = withId;
+    this.name = withName;
+    this.aadGroupId = withAadGroupId;
+  }
+}

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TenantInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TenantInfo.java
@@ -29,10 +29,16 @@ public class TenantInfo {
   }
 
   /**
-   * Set Unique identifier representing a tenant.
+   * New instance of TenantInfo.
    * @param withId Unique identifier representing a tenant.
    */
   public TenantInfo(String withId) {
     this.id = withId;
+  }
+
+  /**
+   * New instance of TenantInfo.
+   */
+  public TenantInfo() {
   }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TenantInfo.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/TenantInfo.java
@@ -1,0 +1,38 @@
+package com.microsoft.bot.schema.teams;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Describes a tenant.
+*/
+public class TenantInfo {
+  /**
+   * Unique identifier representing a tenant.
+   */
+  @JsonProperty(value = "id")
+  private String id;
+
+  /**
+   * Get Unique identifier representing a tenant.
+   * @return Unique identifier representing a tenant.
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Set Unique identifier representing a tenant.
+   * @param withId Unique identifier representing a tenant.
+   */
+  public void setId(String withId) {
+    this.id = withId;
+  }
+
+  /**
+   * Set Unique identifier representing a tenant.
+   * @param withId Unique identifier representing a tenant.
+   */
+  public TenantInfo(String withId) {
+    this.id = withId;
+  }
+}

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/package-info.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/package-info.java
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+/**
+ * This package contains the models classes for bot-schema.
+ */
+package com.microsoft.bot.schema.teams;

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
@@ -199,6 +199,7 @@ public class ActivityTest {
     }
 
     private static final String serializedActivityFromTeams = "{" +
+        " \"channelId\": \"msteams\"," +
         " \"channelData\": {" +
         "   \"teamsChannelId\": \"19:123cb42aa5a0a7e56f83@thread.skype\"," +
         "   \"teamsTeamId\": \"19:104f2cb42aa5a0a7e56f83@thread.skype\"," +
@@ -222,6 +223,7 @@ public class ActivityTest {
         "}";
 
     private static final String serializedActivityFromTeamsWithoutTeamsChannelIdorTeamId = "{" +
+        " \"channelId\": \"msteams\"," +
         " \"channelData\": {" +
         "   \"channel\": {" +
         "     \"id\": \"channel_id\"," +
@@ -251,6 +253,7 @@ public class ActivityTest {
         Activity activity = objectMapper.readValue(ActivityTest.serializedActivityFromTeams, Activity.class);
         Assert.assertEquals("19:123cb42aa5a0a7e56f83@thread.skype", activity.teamsGetChannelId());
         Assert.assertEquals("19:104f2cb42aa5a0a7e56f83@thread.skype", activity.teamsGetTeamId());
+        Assert.assertEquals(true, activity.isTeamsActivity());
 
         activity = objectMapper.readValue(
             ActivityTest.serializedActivityFromTeamsWithoutTeamsChannelIdorTeamId, Activity.class);

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
@@ -3,6 +3,8 @@ package com.microsoft.bot.schema;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.microsoft.bot.schema.teams.TeamChannelData;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -194,6 +196,77 @@ public class ActivityTest {
         Assert.assertNotNull(activity.getTimestamp());
         Assert.assertEquals("b18a1c99-7a29-4801-ac0c-579f2c36d52c", activity.getConversation().getId());
         Assert.assertNotNull(activity.getValue());
+    }
+
+    private static final String serializedActivityFromTeams = "{" +
+        " \"channelData\": {" +
+        "   \"teamsChannelId\": \"19:123cb42aa5a0a7e56f83@thread.skype\"," +
+        "   \"teamsTeamId\": \"19:104f2cb42aa5a0a7e56f83@thread.skype\"," +
+        "   \"channel\": {" +
+        "     \"id\": \"19:4104f2cb42aa5a0a7e56f83@thread.skype\"," +
+        "     \"name\": \"General\" " +
+        "   }," +
+        "   \"team\": {" +
+        "     \"id\": \"19:aab4104f2cb42aa5a0a7e56f83@thread.skype\"," +
+        "     \"name\": \"Kahoot\", " +
+        "     \"aadGroupId\": \"0ac65971-e8a0-49a1-8d41-26089125ea30\"" +
+        "   }," +
+        "   \"notification\": {" +
+        "     \"alert\": \"true\"" +
+        "   }," +
+        "   \"eventType\":\"teamMemberAdded\", " +
+        "   \"tenant\": {" +
+        "     \"id\": \"0-b827-4bb0-9df1-e02faba7ac20\"" +
+        "   }" +
+        " }" +
+        "}";
+
+    private static final String serializedActivityFromTeamsWithoutTeamsChannelIdorTeamId = "{" +
+        " \"channelData\": {" +
+        "   \"channel\": {" +
+        "     \"id\": \"channel_id\"," +
+        "     \"name\": \"channel_name\" " +
+        "   }," +
+        "   \"team\": {" +
+        "     \"id\": \"team_id\"," +
+        "     \"name\": \"team_name\", " +
+        "     \"aadGroupId\": \"aad_groupid\"" +
+        "   }," +
+        "   \"notification\": {" +
+        "     \"alert\": \"true\"" +
+        "   }," +
+        "   \"eventType\":\"teamMemberAdded\", " +
+        "   \"tenant\": {" +
+        "     \"id\": \"tenant_id\"" +
+        "   }" +
+        " }" +
+        "}";
+
+
+
+    @Test
+    public void GetInformationForMicrosoftTeams() throws JsonProcessingException, IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+        Activity activity = objectMapper.readValue(ActivityTest.serializedActivityFromTeams, Activity.class);
+        Assert.assertEquals("19:123cb42aa5a0a7e56f83@thread.skype", activity.teamsGetChannelId());
+        Assert.assertEquals("19:104f2cb42aa5a0a7e56f83@thread.skype", activity.teamsGetTeamId());
+
+        activity = objectMapper.readValue(
+            ActivityTest.serializedActivityFromTeamsWithoutTeamsChannelIdorTeamId, Activity.class);
+
+        Assert.assertEquals("channel_id", activity.teamsGetChannelId());
+        Assert.assertEquals("team_id", activity.teamsGetTeamId());
+
+        TeamChannelData teamsChannelData = activity.getChannelData(TeamChannelData.class);
+        Assert.assertEquals("channel_id", teamsChannelData.getChannel().getId());
+        Assert.assertEquals("channel_name", teamsChannelData.getChannel().getName());
+        Assert.assertEquals("team_id", teamsChannelData.getTeam().getId());
+        Assert.assertEquals("team_name", teamsChannelData.getTeam().getName());
+        Assert.assertEquals("aad_groupid", teamsChannelData.getTeam().getAadGroupId());
+        Assert.assertEquals(true, teamsChannelData.getNotification().getAlert());
+        Assert.assertEquals("teamMemberAdded", teamsChannelData.getEventType());
+        Assert.assertEquals("tenant_id", teamsChannelData.getTenant().getId());
     }
 
 }


### PR DESCRIPTION
It seems like Micosoft Teams embeds relevant information in "channelData" with its own schema.

This PR ports schema for Microsoft Teams from the dotnet SDK.

https://github.com/microsoft/botbuilder-dotnet/tree/master/libraries/Microsoft.Bot.Schema/Teams/Generated
 
This is quite important to have a bot to send proactive messages to a channel since this is the only way to access the real channel id which the bot has been added to.