### PR TITLE
Remove the unnecessary filtering, the bot itself has been filtered out already in ActivityHandler.java

### DIFF
--- a/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/ProactiveBot.java
+++ b/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/ProactiveBot.java
@@ -10,7 +10,6 @@ import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ChannelAccount;
 import com.microsoft.bot.schema.ConversationReference;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -58,10 +57,6 @@ public class ProactiveBot extends ActivityHandler {
         TurnContext turnContext
     ) {
         return membersAdded.stream()
-            .filter(
-                member -> !StringUtils
-                    .equals(member.getId(), turnContext.getActivity().getRecipient().getId())
-            )
             .map(
                 channel -> turnContext
                     .sendActivity(MessageFactory.text(String.format(WELCOMEMESSAGE, port)))


### PR DESCRIPTION
The bot itself has been filtered in activityHandler.java see:

https://github.com/microsoft/botbuilder-java/blob/45ad1e09e19ee757177aefc2d9f627b409453e81/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/ActivityHandler.java#L142

Suggest removing this line from the sample since it's quite confusing, it could lead people to think onMembersAdded will be called when the bot is added to the channel,  which is reasonable since bot service does send out MemebersAdd when a bot is added.

This, of course, will never happen.
