### PR TITLE
BotFrameworkAdapter auth flow/CallerId

### DIFF
--- a/etc/botframework-java-formatter.xml
+++ b/etc/botframework-java-formatter.xml
@@ -131,7 +131,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="64"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotAdapter.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotAdapter.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.builder;
 
+import com.microsoft.bot.connector.authentication.ClaimsIdentity;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ConversationReference;
 import com.microsoft.bot.schema.ResourceResponse;
@@ -10,6 +11,7 @@ import com.microsoft.bot.schema.ResourceResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Represents a bot adapter that can connect a bot to a service endpoint. This
@@ -32,6 +34,16 @@ import java.util.concurrent.CompletionException;
  * {@link TurnContext} {@link Activity} {@link Bot} {@link Middleware}
  */
 public abstract class BotAdapter {
+    /**
+     * Key to store bot claims identity.
+     */
+    public static final String BOT_IDENTITY_KEY = "BotIdentity";
+
+    /**
+     * Key to store bot oauth scope.
+     */
+    public static final String OAUTH_SCOPE_KEY = "Microsoft.Bot.Builder.BotAdapter.OAuthScope";
+
     /**
      * The collection of middleware in the adapter's pipeline.
      */
@@ -213,18 +225,66 @@ public abstract class BotAdapter {
         ConversationReference reference,
         BotCallbackHandler callback
     ) {
-
         CompletableFuture<Void> pipelineResult = new CompletableFuture<>();
 
-        try (TurnContextImpl context = new TurnContextImpl(
-            this,
-            reference.getContinuationActivity()
-        )) {
+        try (TurnContextImpl context =
+            new TurnContextImpl(this, reference.getContinuationActivity())) {
             pipelineResult = runPipeline(context, callback);
         } catch (Exception e) {
             pipelineResult.completeExceptionally(e);
         }
 
         return pipelineResult;
+    }
+
+    /**
+     * Sends a proactive message to a conversation.
+     *
+     * <p>
+     * Call this method to proactively send a message to a conversation. Most
+     * channels require a user to initiate a conversation with a bot before the bot
+     * can send activities to the user.
+     * </p>
+     *
+     * @param claimsIdentity A ClaimsIdentity reference for the conversation.
+     * @param reference      A reference to the conversation to continue.
+     * @param callback       The method to call for the result bot turn.
+     * @return A task that represents the work queued to execute.
+     */
+    public CompletableFuture<Void> continueConversation(
+        ClaimsIdentity claimsIdentity,
+        ConversationReference reference,
+        BotCallbackHandler callback
+    ) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        result.completeExceptionally(new NotImplementedException("continueConversation"));
+        return result;
+    }
+
+    /**
+     * Sends a proactive message to a conversation.
+     *
+     * <p>
+     * Call this method to proactively send a message to a conversation. Most
+     * channels require a user to initiate a conversation with a bot before the bot
+     * can send activities to the user.
+     * </p>
+     *
+     * @param claimsIdentity A ClaimsIdentity reference for the conversation.
+     * @param reference      A reference to the conversation to continue.
+     * @param audience       A value signifying the recipient of the proactive
+     *                       message.
+     * @param callback       The method to call for the result bot turn.
+     * @return A task that represents the work queued to execute.
+     */
+    public CompletableFuture<Void> continueConversation(
+        ClaimsIdentity claimsIdentity,
+        ConversationReference reference,
+        String audience,
+        BotCallbackHandler callback
+    ) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        result.completeExceptionally(new NotImplementedException("continueConversation"));
+        return result;
     }
 }

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/BotFrameworkAdapterTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/BotFrameworkAdapterTests.java
@@ -8,15 +8,21 @@ import com.microsoft.bot.connector.Channels;
 import com.microsoft.bot.connector.ConnectorClient;
 import com.microsoft.bot.connector.Conversations;
 import com.microsoft.bot.connector.authentication.AppCredentials;
+import com.microsoft.bot.connector.authentication.AuthenticationConstants;
 import com.microsoft.bot.connector.authentication.ClaimsIdentity;
 import com.microsoft.bot.connector.authentication.CredentialProvider;
+import com.microsoft.bot.connector.authentication.GovernmentAuthenticationConstants;
 import com.microsoft.bot.connector.authentication.MicrosoftAppCredentials;
+import com.microsoft.bot.connector.authentication.SimpleChannelProvider;
 import com.microsoft.bot.connector.authentication.SimpleCredentialProvider;
 import com.microsoft.bot.schema.Activity;
+import com.microsoft.bot.schema.CallerIdConstants;
 import com.microsoft.bot.schema.ConversationAccount;
 import com.microsoft.bot.schema.ConversationParameters;
 import com.microsoft.bot.schema.ConversationReference;
 import com.microsoft.bot.schema.ConversationResourceResponse;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,10 +93,8 @@ public class BotFrameworkAdapterTests {
         ObjectNode channelData = JsonNodeFactory.instance.objectNode();
         channelData.set(
             "tenant",
-            JsonNodeFactory.instance.objectNode().set(
-                "id",
-                JsonNodeFactory.instance.textNode(TenantIdValue)
-            )
+            JsonNodeFactory.instance.objectNode()
+                .set("id", JsonNodeFactory.instance.textNode(TenantIdValue))
         );
 
         Activity activity = new Activity("Test") {
@@ -119,7 +123,7 @@ public class BotFrameworkAdapterTests {
         ConversationReference reference = activity.getConversationReference();
         MicrosoftAppCredentials credentials = new MicrosoftAppCredentials(null, null);
 
-        Activity[] newActivity = new Activity[] { null };
+        Activity[] newActivity = new Activity[] {null};
         BotCallbackHandler updateParameters = (turnContext -> {
             newActivity[0] = turnContext.getActivity();
             return CompletableFuture.completedFuture(null);
@@ -159,7 +163,7 @@ public class BotFrameworkAdapterTests {
         tenantId.put("id", channelDataTenantId);
         channelData.set("tenant", tenantId);
 
-        Activity[] activity = new Activity[] { null };
+        Activity[] activity = new Activity[] {null};
         sut.processActivity(mockClaims, new Activity("test") {
             {
                 setChannelId(channelId);
@@ -177,5 +181,184 @@ public class BotFrameworkAdapterTests {
         }).join();
 
         return activity[0];
+    }
+
+    @Test
+    public void OutgoingActivityIdNotSent() {
+        CredentialProvider mockCredentials = mock(CredentialProvider.class);
+        BotFrameworkAdapter adapter = new BotFrameworkAdapter(mockCredentials);
+
+        Activity incoming_activity = new Activity("test") {
+            {
+                setId("testid");
+                setChannelId(Channels.DIRECTLINE);
+                setServiceUrl("https://fake.service.url");
+                setConversation(new ConversationAccount("cid"));
+            }
+        };
+
+        Activity reply = MessageFactory.text("test");
+        reply.setId("TestReplyId");
+
+        MemoryConnectorClient mockConnector = new MemoryConnectorClient();
+        TurnContext turnContext = new TurnContextImpl(adapter, incoming_activity);
+        turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, mockConnector);
+        turnContext.sendActivity(reply).join();
+
+        Assert.assertEquals(
+            1,
+            ((MemoryConversations) mockConnector.getConversations()).getSentActivities().size()
+        );
+        Assert.assertNull(
+            ((MemoryConversations) mockConnector.getConversations()).getSentActivities().get(0).getId()
+        );
+    }
+
+    @Test
+    public void processActivityCreatesCorrectCredsAndClient_anon() {
+        processActivityCreatesCorrectCredsAndClient(
+            null,
+            null,
+            null,
+            AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE,
+            0,
+            1
+        );
+    }
+
+    @Test
+    public void processActivityCreatesCorrectCredsAndClient_public() {
+        processActivityCreatesCorrectCredsAndClient(
+            "00000000-0000-0000-0000-000000000001",
+            CallerIdConstants.PUBLIC_AZURE_CHANNEL,
+            null,
+            AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE,
+            1,
+            1
+        );
+    }
+
+    @Test
+    public void processActivityCreatesCorrectCredsAndClient_gov() {
+        processActivityCreatesCorrectCredsAndClient(
+            "00000000-0000-0000-0000-000000000001",
+            CallerIdConstants.US_GOV_CHANNEL,
+            GovernmentAuthenticationConstants.CHANNELSERVICE,
+            GovernmentAuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE,
+            1,
+            1
+        );
+    }
+
+    private void processActivityCreatesCorrectCredsAndClient(
+        String botAppId,
+        String expectedCallerId,
+        String channelService,
+        String expectedScope,
+        int expectedAppCredentialsCount,
+        int expectedClientCredentialsCount
+    ) {
+        HashMap<String, String> claims = new HashMap<String, String>() {
+            {
+                put(AuthenticationConstants.AUDIENCE_CLAIM, botAppId);
+                put(AuthenticationConstants.APPID_CLAIM, botAppId);
+                put(AuthenticationConstants.VERSION_CLAIM, "1.0");
+            }
+        };
+        ClaimsIdentity identity = new ClaimsIdentity("anonymous", claims);
+
+        CredentialProvider credentialProvider = new SimpleCredentialProvider() {
+            {
+                setAppId(botAppId);
+            }
+        };
+        String serviceUrl = "https://smba.trafficmanager.net/amer/";
+
+        BotFrameworkAdapter sut = new BotFrameworkAdapter(
+            credentialProvider,
+            new SimpleChannelProvider(channelService),
+            null,
+            null
+        );
+
+        BotCallbackHandler callback = turnContext -> {
+            getAppCredentialsAndAssertValues(
+                turnContext,
+                botAppId,
+                expectedScope,
+                expectedAppCredentialsCount
+            );
+
+            getConnectorClientAndAssertValues(
+                turnContext,
+                botAppId,
+                expectedScope,
+                serviceUrl,
+                expectedClientCredentialsCount
+            );
+
+            Assert.assertEquals(expectedCallerId, turnContext.getActivity().getCallerId());
+
+            return CompletableFuture.completedFuture(null);
+        };
+
+        sut.processActivity(identity, new Activity("test") {
+            {
+                setChannelId(Channels.EMULATOR);
+                setServiceUrl(serviceUrl);
+            }
+        }, callback).join();
+    }
+
+    private static void getAppCredentialsAndAssertValues(
+        TurnContext turnContext,
+        String expectedAppId,
+        String expectedScope,
+        int credsCount
+    ) {
+        if (credsCount > 0) {
+            Map<String, AppCredentials> credsCache =
+                ((BotFrameworkAdapter) turnContext.getAdapter()).getCredentialsCache();
+            AppCredentials creds = credsCache
+                .get(BotFrameworkAdapter.keyForAppCredentials(expectedAppId, expectedScope));
+
+            Assert
+                .assertEquals("Unexpected credentials cache count", credsCount, credsCache.size());
+
+            Assert.assertNotNull("Credentials not found", creds);
+            Assert.assertEquals("Unexpected app id", expectedAppId, creds.getAppId());
+            Assert.assertEquals("Unexpected scope", expectedScope, creds.oAuthScope());
+        }
+    }
+
+    private static void getConnectorClientAndAssertValues(
+        TurnContext turnContext,
+        String expectedAppId,
+        String expectedScope,
+        String expectedUrl,
+        int clientCount
+    ) {
+        Map<String, ConnectorClient> clientCache =
+            ((BotFrameworkAdapter) turnContext.getAdapter()).getConnectorClientCache();
+
+        String cacheKey = expectedAppId == null
+            ? BotFrameworkAdapter.keyForConnectorClient(expectedUrl, null, null)
+            : BotFrameworkAdapter.keyForConnectorClient(expectedUrl, expectedAppId, expectedScope);
+        ConnectorClient client = clientCache.get(cacheKey);
+
+        Assert.assertNotNull("ConnectorClient not in cache", client);
+        Assert.assertEquals("Unexpected credentials cache count", clientCount, clientCache.size());
+        AppCredentials creds = (AppCredentials) client.credentials();
+        Assert.assertEquals(
+            "Unexpected app id",
+            expectedAppId,
+            creds == null ? null : creds.getAppId()
+        );
+        Assert.assertEquals(
+            "Unexpected scope",
+            expectedScope,
+            creds == null ? null : creds.oAuthScope()
+        );
+        Assert.assertEquals("Unexpected base url", expectedUrl, client.baseUrl());
     }
 }

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MemoryConnectorClient.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MemoryConnectorClient.java
@@ -1,0 +1,76 @@
+package com.microsoft.bot.builder;
+
+import com.microsoft.bot.connector.Attachments;
+import com.microsoft.bot.connector.ConnectorClient;
+import com.microsoft.bot.connector.Conversations;
+import com.microsoft.bot.rest.RestClient;
+import com.microsoft.bot.rest.credentials.ServiceClientCredentials;
+
+public class MemoryConnectorClient implements ConnectorClient {
+    private MemoryConversations conversations = new MemoryConversations();
+
+    @Override
+    public RestClient getRestClient() {
+        return null;
+    }
+
+    @Override
+    public String baseUrl() {
+        return null;
+    }
+
+    @Override
+    public ServiceClientCredentials credentials() {
+        return null;
+    }
+
+    @Override
+    public String getUserAgent() {
+        return null;
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return null;
+    }
+
+    @Override
+    public void setAcceptLanguage(String acceptLanguage) {
+
+    }
+
+    @Override
+    public int getLongRunningOperationRetryTimeout() {
+        return 0;
+    }
+
+    @Override
+    public void setLongRunningOperationRetryTimeout(int timeout) {
+
+    }
+
+    @Override
+    public boolean getGenerateClientRequestId() {
+        return false;
+    }
+
+    @Override
+    public void setGenerateClientRequestId(boolean generateClientRequestId) {
+
+    }
+
+    @Override
+    public Attachments getAttachments() {
+        return null;
+    }
+
+    @Override
+    public Conversations getConversations() {
+        return conversations;
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+}

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MemoryConversations.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MemoryConversations.java
@@ -1,0 +1,145 @@
+package com.microsoft.bot.builder;
+
+import com.microsoft.bot.connector.Conversations;
+import com.microsoft.bot.schema.Activity;
+import com.microsoft.bot.schema.AttachmentData;
+import com.microsoft.bot.schema.ChannelAccount;
+import com.microsoft.bot.schema.ConversationParameters;
+import com.microsoft.bot.schema.ConversationResourceResponse;
+import com.microsoft.bot.schema.ConversationsResult;
+import com.microsoft.bot.schema.PagedMembersResult;
+import com.microsoft.bot.schema.ResourceResponse;
+import com.microsoft.bot.schema.Transcript;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.NotImplementedException;
+
+public class MemoryConversations implements Conversations {
+    private List<Activity> sentActivities = new ArrayList<>();
+
+    public List<Activity> getSentActivities() {
+        return sentActivities;
+    }
+
+    @Override
+    public CompletableFuture<ConversationsResult> getConversations() {
+        return notImplemented("getConversations");
+    }
+
+    @Override
+    public CompletableFuture<ConversationsResult> getConversations(String continuationToken) {
+        return notImplemented("getConversations");
+    }
+
+    @Override
+    public CompletableFuture<ConversationResourceResponse> createConversation(
+        ConversationParameters parameters
+    ) {
+        return notImplemented("createConversation");
+    }
+
+    @Override
+    public CompletableFuture<ResourceResponse> sendToConversation(
+        String conversationId,
+        Activity activity
+    ) {
+        sentActivities.add(activity);
+        return CompletableFuture.completedFuture(new ResourceResponse() {
+            {
+                setId(activity.getId());
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<ResourceResponse> updateActivity(
+        String conversationId, String activityId,
+        Activity activity
+    ) {
+        return notImplemented("updateActivity");
+    }
+
+    @Override
+    public CompletableFuture<ResourceResponse> replyToActivity(
+        String conversationId, String activityId,
+        Activity activity
+    ) {
+        sentActivities.add(activity);
+        return CompletableFuture.completedFuture(new ResourceResponse() {
+            {
+                setId(activity.getId());
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteActivity(String conversationId, String activityId) {
+        return notImplemented("deleteActivity");
+    }
+
+    @Override
+    public CompletableFuture<List<ChannelAccount>> getConversationMembers(
+        String conversationId
+    ) {
+        return notImplemented("getConversationMembers");
+    }
+
+    @Override
+    public CompletableFuture<ChannelAccount> getConversationMember(
+        String userId, String conversationId
+    ) {
+        return notImplemented("getConversationMember");
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteConversationMember(
+        String conversationId, String memberId
+    ) {
+        return notImplemented("deleteConversationMember");
+    }
+
+    @Override
+    public CompletableFuture<List<ChannelAccount>> getActivityMembers(
+        String conversationId, String activityId
+    ) {
+        return notImplemented("getActivityMembers");
+    }
+
+    @Override
+    public CompletableFuture<ResourceResponse> uploadAttachment(
+        String conversationId, AttachmentData attachmentUpload
+    ) {
+        return notImplemented("uploadAttachment");
+    }
+
+    @Override
+    public CompletableFuture<ResourceResponse> sendConversationHistory(
+        String conversationId, Transcript history
+    ) {
+        return notImplemented("sendConversationHistory");
+    }
+
+    @Override
+    public CompletableFuture<PagedMembersResult> getConversationPagedMembers(
+        String conversationId
+    ) {
+        return notImplemented("getConversationPagedMembers");
+    }
+
+    @Override
+    public CompletableFuture<PagedMembersResult> getConversationPagedMembers(
+        String conversationId,
+        String continuationToken
+    ) {
+        return notImplemented("getConversationPagedMembers");
+    }
+
+    protected <T> CompletableFuture<T> notImplemented(String message) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        result.completeExceptionally(
+            new NotImplementedException(message)
+        );
+        return result;
+    }
+}

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/JwtTokenValidation.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/JwtTokenValidation.java
@@ -4,6 +4,7 @@
 package com.microsoft.bot.connector.authentication;
 
 import com.microsoft.bot.schema.Activity;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.concurrent.CompletableFuture;
@@ -169,5 +170,37 @@ public final class JwtTokenValidation {
                 authHeader, credentials, channelProvider, serviceUrl, channelId, authConfig
             );
         }
+    }
+
+    /**
+     * Gets the AppId from claims.
+     *
+     * <p>
+     * In v1 tokens the AppId is in the the AppIdClaim claim. In v2 tokens the AppId
+     * is in the AuthorizedParty claim.
+     * </p>
+     *
+     * @param claims The map of claims.
+     * @return The value of the appId claim if found (null if it can't find a
+     *         suitable claim).
+     */
+    public static String getAppIdFromClaims(Map<String, String> claims) {
+        if (claims == null) {
+            throw new IllegalArgumentException("claims");
+        }
+
+        String appId = null;
+
+        String tokenVersion = claims.get(AuthenticationConstants.VERSION_CLAIM);
+        if (StringUtils.isEmpty(tokenVersion) || tokenVersion.equalsIgnoreCase("1.0")) {
+            // either no Version or a version of "1.0" means we should look for the claim in
+            // the "appid" claim.
+            appId = claims.get(AuthenticationConstants.APPID_CLAIM);
+        } else {
+            // "2.0" puts the AppId in the "azp" claim.
+            appId = claims.get(AuthenticationConstants.AUTHORIZED_PARTY);
+        }
+
+        return appId;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/TokenExchangeState.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/TokenExchangeState.java
@@ -26,9 +26,13 @@ public class TokenExchangeState {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private String botUrl;
 
+    @JsonProperty("relatesTo")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private ConversationReference relatesTo;
+
     /**
      * The connection name that was used.
-     * 
+     *
      * @return The connection name.
      */
     public String getConnectionName() {
@@ -37,7 +41,7 @@ public class TokenExchangeState {
 
     /**
      * The connection name that was used.
-     * 
+     *
      * @param withConnectionName The connection name.
      */
     public void setConnectionName(String withConnectionName) {
@@ -46,7 +50,7 @@ public class TokenExchangeState {
 
     /**
      * A reference to the conversation.
-     * 
+     *
      * @return The conversation reference.
      */
     public ConversationReference getConversation() {
@@ -55,7 +59,7 @@ public class TokenExchangeState {
 
     /**
      * A reference to the conversation.
-     * 
+     *
      * @param withConversation The conversation reference.
      */
     public void setConversation(ConversationReference withConversation) {
@@ -64,7 +68,7 @@ public class TokenExchangeState {
 
     /**
      * The URL of the bot messaging endpoint.
-     * 
+     *
      * @return The messaging endpoint.
      */
     public String getBotUrl() {
@@ -73,7 +77,7 @@ public class TokenExchangeState {
 
     /**
      * The URL of the bot messaging endpoint.
-     * 
+     *
      * @param withBotUrl The messaging endpoint.
      */
     public void setBotUrl(String withBotUrl) {
@@ -82,7 +86,7 @@ public class TokenExchangeState {
 
     /**
      * The bot's registered application ID.
-     * 
+     *
      * @return The app id.
      */
     public String getMsAppId() {
@@ -91,10 +95,28 @@ public class TokenExchangeState {
 
     /**
      * The bot's registered application ID.
-     * 
+     *
      * @param withMsAppId The app id.
      */
     public void setMsAppId(String withMsAppId) {
         this.msAppId = withMsAppId;
+    }
+
+    /**
+     * Gets the reference to a related parent conversation for this token exchange.
+     *
+     * @return A reference to a related parent conversation.
+     */
+    public ConversationReference getRelatesTo() {
+        return relatesTo;
+    }
+
+    /**
+     * Sets the reference to a related parent conversation for this token exchange.
+     *
+     * @param withRelatesTo A reference to a related parent conversation.
+     */
+    public void setRelatesTo(ConversationReference withRelatesTo) {
+        relatesTo = withRelatesTo;
     }
 }


### PR DESCRIPTION
Fixes #315 

In so far as it can without skills.  There was a great deal of auth flow changes.  This PR brings Java to parity with that.  Skills changes will come when Skills features are added.