### PR TITLE
Add test for toAttachment methods in Card's classes

### DIFF
--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AnimationCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AnimationCardTest.java
@@ -20,10 +20,10 @@ public class AnimationCardTest {
         }
     };
 
-    @Test
     /**
      *Ensures that the AnimationCard can be used as an attachment.
      */
+    @Test
     public void testToAttachment() {
         Attachment attachment = card.toAttachment();
         Assert.assertNotNull(attachment);

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AudioCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AudioCardTest.java
@@ -20,10 +20,10 @@ public class AudioCardTest {
         };
     };
 
-    @Test
     /**
      *Ensures that the AudioCard can be used as an attachment.
      */
+    @Test
     public void testToAttachment() {
         Attachment attachment = card.toAttachment();
         Assert.assertNotNull(attachment);

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/HeroCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/HeroCardTest.java
@@ -6,6 +6,9 @@ package com.microsoft.bot.schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+/***
+ * Tests to ensure the HeroCard methods work as expected.
+ */
 public class HeroCardTest {
     HeroCard card = new HeroCard(){
         {

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/HeroCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/HeroCardTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.bot.schema;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HeroCardTest {
+    HeroCard card = new HeroCard(){
+        {
+            setTitle("Hero Card Title");
+            setSubtitle("Hero Card Subtitle");
+            setText("Testing Text.");
+        }
+    };
+
+    /**
+     * Ensures that the HeroCard can be added as an attachment.
+     */
+    @Test
+    public void testToAttachment() {
+        Attachment attachment = card.toAttachment();
+        Assert.assertNotNull(attachment);
+        Assert.assertEquals("application/vnd.microsoft.card.hero", attachment.getContentType());
+    }
+}

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/OAuthCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/OAuthCardTest.java
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.bot.schema;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OAuthCardTest {
+    OAuthCard card = new OAuthCard(){
+        {
+            setText("Test OAuth Text");
+            setConnectionName("Test Connection Name");
+        }
+    };
+
+    @Test
+    public void testToAttachment() {
+        Attachment attachment = card.toAttachment();
+        Assert.assertNotNull(attachment);
+        Assert.assertEquals("application/vnd.microsoft.card.oauth", attachment.getContentType());
+    }
+}

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/OAuthCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/OAuthCardTest.java
@@ -6,6 +6,9 @@ package com.microsoft.bot.schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+/***
+ * Tests to ensure the OAuthCard methods work as expected.
+ */
 public class OAuthCardTest {
     OAuthCard card = new OAuthCard(){
         {

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ReceiptCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ReceiptCardTest.java
@@ -6,6 +6,9 @@ package com.microsoft.bot.schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+/***
+ * Tests to ensure the AnimationCard methods work as expected.
+ */
 public class ReceiptCardTest {
 
     ReceiptCard card = new ReceiptCard() {

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ReceiptCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ReceiptCardTest.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.bot.schema;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReceiptCardTest {
+
+    ReceiptCard card = new ReceiptCard() {
+        {
+            setTitle("John Doe");
+        }
+    };
+
+    /**
+     * Ensures that the ReceiptCard can be added as an attachment.
+     */
+    @Test
+    public void testToAttachment() {
+        Attachment attachment = card.toAttachment();
+        Assert.assertNotNull(attachment);
+        Assert.assertEquals("application/vnd.microsoft.card.receipt", attachment.getContentType());
+    }
+}

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/SigninCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/SigninCardTest.java
@@ -6,6 +6,9 @@ package com.microsoft.bot.schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+/***
+ * Tests to ensure the SigninCard methods work as expected.
+ */
 public class SigninCardTest {
     SigninCard card = new SigninCard(){
         {

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ThumbnailCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ThumbnailCardTest.java
@@ -6,6 +6,9 @@ package com.microsoft.bot.schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+/***
+ * Tests to ensure the ThumbnailCard methods work as expected.
+ */
 public class ThumbnailCardTest {
     ThumbnailCard card = new ThumbnailCard(){
         {

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/VideoCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/VideoCardTest.java
@@ -6,6 +6,9 @@ package com.microsoft.bot.schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+/***
+ * Tests to ensure the VideoCard methods work as expected.
+ */
 public class VideoCardTest {
     VideoCard card = new VideoCard(){
         {


### PR DESCRIPTION
Fixes #591

## Description
This pull request adds tests for the `toAttachment` methods of the cards from BotBuilder-Schema.

The `toAttachment` method is already implemented in the cards, including the `OAuthCard` class

## Specific Changes
Added the following test classes:
- AnimationCardTest.java
- AudioCardTest.java
- HeroCardTest.java
- OAuthCardTest.java
- ReceiptCardTest.java
- SigninCardTest.java
- ThumbnailCardTest.java
- VideoCardTest.java

Each class contains a test method that validates the `toAttachment()` from each of the cards.
## Testing
![image](https://user-images.githubusercontent.com/38112957/85069455-88fb5f80-b18a-11ea-9569-4ccc7e9db547.png)
