### PR TITLE
Add linkToMessage property to MessageActionsPayload class

### DIFF
--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/MessageActionsPayload.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/MessageActionsPayload.java
@@ -40,6 +40,9 @@ public class MessageActionsPayload {
     @JsonProperty(value = "importance")
     private String importance;
 
+    @JsonProperty(value = "linkToMessage")
+    private String linkToMessage;
+
     @JsonProperty(value = "locale")
     private String locale;
 
@@ -66,7 +69,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets unique id of the message.
-     * 
+     *
      * @return The unique id.
      */
     public String getId() {
@@ -75,7 +78,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets unique id of the message.
-     * 
+     *
      * @param withId The new id of the message.
      */
     public void setId(String withId) {
@@ -84,7 +87,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets id of the parent/root message of the thread.
-     * 
+     *
      * @return The id of the parent/root message.
      */
     public String getReplyToId() {
@@ -93,7 +96,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets id of the parent/root message of the thread.
-     * 
+     *
      * @param withReplyToId The id of the parent/root message.
      */
     public void setReplyToId(String withReplyToId) {
@@ -102,7 +105,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets type of message - automatically set to message.
-     * 
+     *
      * @return Possible values include: 'message'
      */
     public String getMessageType() {
@@ -111,7 +114,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets type of message.
-     * 
+     *
      * @param withMessageType Possible values include: 'message'
      */
     public void setMessageType(String withMessageType) {
@@ -120,7 +123,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets timestamp of when the message was created.
-     * 
+     *
      * @return The timestamp of the message.
      */
     public String getCreatedDateTime() {
@@ -129,7 +132,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets timestamp of when the message was created.
-     * 
+     *
      * @param withCreatedDateTime The message timestamp.
      */
     public void setCreatedDateTime(String withCreatedDateTime) {
@@ -138,7 +141,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets timestamp of when the message was edited or updated.
-     * 
+     *
      * @return The timestamp of the message.
      */
     public String getLastModifiedDateTime() {
@@ -147,7 +150,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets timestamp of when the message was edited or updated.
-     * 
+     *
      * @param withLastModifiedDateTime The message timestamp.
      */
     public void setLastModifiedDateTime(String withLastModifiedDateTime) {
@@ -156,7 +159,7 @@ public class MessageActionsPayload {
 
     /**
      * Indicates whether a message has been soft deleted.
-     * 
+     *
      * @return True if deleted.
      */
     public Boolean getDeleted() {
@@ -165,7 +168,7 @@ public class MessageActionsPayload {
 
     /**
      * Indicates whether a message has been soft deleted.
-     * 
+     *
      * @param withDeleted True if deleted.
      */
     public void setDeleted(Boolean withDeleted) {
@@ -174,7 +177,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets subject line of the message.
-     * 
+     *
      * @return The message subject line.
      */
     public String getSubject() {
@@ -183,7 +186,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets subject line of the message.
-     * 
+     *
      * @param withSubject The message subject line.
      */
     public void setSubject(String withSubject) {
@@ -192,7 +195,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets summary text of the message that could be used for notifications.
-     * 
+     *
      * @return The summary text.
      */
     public String getSummary() {
@@ -201,7 +204,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets summary text of the message that could be used for notifications.
-     * 
+     *
      * @param withSummary The summary text.
      */
     public void setSummary(String withSummary) {
@@ -210,7 +213,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets the importance of the message.
-     * 
+     *
      * @return Possible values include: 'normal', 'high', 'urgent'
      */
     public String getImportance() {
@@ -219,7 +222,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets the importance of the message.
-     * 
+     *
      * @param withImportance Possible values include: 'normal', 'high', 'urgent'
      */
     public void setImportance(String withImportance) {
@@ -227,8 +230,22 @@ public class MessageActionsPayload {
     }
 
     /**
+     * Gets the link back to the message
+     *
+     * @return The link back to the message.
+     */
+    public String getLinkToMessage() { return linkToMessage; }
+
+    /**
+     * Sets link back to the message.
+     *
+     * @param withLinkToMessage The link back to the message.
+     */
+    public void setLinkToMessage(String withLinkToMessage) { linkToMessage = withLinkToMessage; }
+
+    /**
      * Gets locale of the message set by the client.
-     * 
+     *
      * @return The message locale.
      */
     public String getLocale() {
@@ -237,7 +254,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets locale of the message set by the client.
-     * 
+     *
      * @param withLocale The message locale.
      */
     public void setLocale(String withLocale) {
@@ -246,7 +263,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets sender of the message.
-     * 
+     *
      * @return The message sender.
      */
     public MessageActionsPayloadFrom getFrom() {
@@ -255,7 +272,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets sender of the message.
-     * 
+     *
      * @param withFrom The message sender.
      */
     public void setFrom(MessageActionsPayloadFrom withFrom) {
@@ -264,7 +281,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets plaintext/HTML representation of the content of the message.
-     * 
+     *
      * @return The message body.
      */
     public MessageActionsPayloadBody getBody() {
@@ -273,7 +290,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets plaintext/HTML representation of the content of the message.
-     * 
+     *
      * @param withBody The message body.
      */
     public void setBody(MessageActionsPayloadBody withBody) {
@@ -282,7 +299,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets how the attachment(s) are displayed in the message.
-     * 
+     *
      * @return The attachment layout.
      */
     public String getAttachmentLayout() {
@@ -291,7 +308,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets how the attachment(s) are displayed in the message.
-     * 
+     *
      * @param withAttachmentLayout The attachment layout.
      */
     public void setAttachmentLayout(String withAttachmentLayout) {
@@ -300,7 +317,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets attachments in the message - card, image, file, etc.
-     * 
+     *
      * @return The message attachments.
      */
     public List<MessageActionsPayloadAttachment> getAttachments() {
@@ -309,7 +326,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets attachments in the message - card, image, file, etc.
-     * 
+     *
      * @param withAttachments The message attachments.
      */
     public void setAttachments(List<MessageActionsPayloadAttachment> withAttachments) {
@@ -318,7 +335,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets list of entities mentioned in the message.
-     * 
+     *
      * @return The list of mentions.
      */
     public List<MessageActionsPayloadMention> getMentions() {
@@ -327,7 +344,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets list of entities mentioned in the message.
-     * 
+     *
      * @param withMentions The list of mentions.
      */
     public void setMentions(List<MessageActionsPayloadMention> withMentions) {
@@ -336,7 +353,7 @@ public class MessageActionsPayload {
 
     /**
      * Gets reactions for the message.
-     * 
+     *
      * @return Message reactions.
      */
     public List<MessageActionsPayloadReaction> getReactions() {
@@ -345,7 +362,7 @@ public class MessageActionsPayload {
 
     /**
      * Sets reactions for the message.
-     * 
+     *
      * @param withReactions Message reactions.
      */
     public void setReactions(List<MessageActionsPayloadReaction> withReactions) {

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/MessageActionsPayload.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/teams/MessageActionsPayload.java
@@ -230,18 +230,22 @@ public class MessageActionsPayload {
     }
 
     /**
-     * Gets the link back to the message
+     * Gets the link back to the message.
      *
      * @return The link back to the message.
      */
-    public String getLinkToMessage() { return linkToMessage; }
+    public String getLinkToMessage() {
+        return linkToMessage;
+    }
 
     /**
      * Sets link back to the message.
      *
      * @param withLinkToMessage The link back to the message.
      */
-    public void setLinkToMessage(String withLinkToMessage) { linkToMessage = withLinkToMessage; }
+    public void setLinkToMessage(String withLinkToMessage) {
+        linkToMessage = withLinkToMessage;
+    }
 
     /**
      * Gets locale of the message set by the client.

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/teams/MessageActionsPayloadTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/teams/MessageActionsPayloadTest.java
@@ -9,13 +9,22 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Tests to ensure that MessageActionsPayload works as expected.
+ */
 public class MessageActionsPayloadTest {
+    /**
+     * Ensures the constructor of the MessageActionsPayload class works as expected.
+     */
     @Test
     public void TestMessageActionPayloadConstructor(){
         MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
         Assert.assertNotNull(messageActionsPayload);
     }
 
+    /**
+     * Ensures that the Id property can be set and retrieved.
+     */
     @Test
     public void TestGetId(){
         String id = "testId";
@@ -29,6 +38,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, id);
     }
 
+    /**
+     * Ensures that the ReplyToId property can be set and retrieved.
+     */
     @Test
     public void TestGetReplyToId(){
         String replyToId = "testReplyToId";
@@ -42,6 +54,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, replyToId);
     }
 
+    /**
+     * Ensures that the MessageType property can be set and retrieved.
+     */
     @Test
     public void TestGetMessageType(){
         String messageType = "testMessageType";
@@ -55,6 +70,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, messageType);
     }
 
+    /**
+     * Ensures that the CreatedDateTime property can be set and retrieved.
+     */
     @Test
     public void TestGetCreatedDateTime(){
         String createdDateTime = "2000-01-01";
@@ -68,6 +86,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, createdDateTime);
     }
 
+    /**
+     * Ensures that the LastModifiedDateTime property can be set and retrieved.
+     */
     @Test
     public void TestGetLastModifiedDateTime(){
         String lastModifiedDateTime = "2000-01-01";
@@ -81,6 +102,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, lastModifiedDateTime);
     }
 
+    /**
+     * Ensures that the Deleted property can be set and retrieved.
+     */
     @Test
     public void TestGetDeleted(){
         Boolean deleted = false;
@@ -94,6 +118,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, deleted);
     }
 
+    /**
+     * Ensures that the Subject property can be set and retrieved.
+     */
     @Test
     public void TestGetSubject(){
         String subject = "testSubject";
@@ -107,6 +134,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, subject);
     }
 
+    /**
+     * Ensures that the Summary property can be set and retrieved.
+     */
     @Test
     public void TestGetSummary(){
         String summary = "testSummary";
@@ -120,6 +150,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, summary);
     }
 
+    /**
+     * Ensures that the Importance property can be set and retrieved.
+     */
     @Test
     public void TestGetImportance(){
         String importance = "normal";
@@ -133,6 +166,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, importance);
     }
 
+    /**
+     * Ensures that the LinkToMessage property can be set and retrieved.
+     */
     @Test
     public void TestGetLinkToMessage(){
         String linkToMessage = "https://teams.microsoft.com/l/message/testing-id";
@@ -146,6 +182,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, linkToMessage);
     }
 
+    /**
+     * Ensures that the Locale property can be set and retrieved.
+     */
     @Test
     public void TestGetLocale(){
         String locale = "US";
@@ -159,6 +198,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, locale);
     }
 
+    /**
+     * Ensures that the From property can be set and retrieved.
+     */
     @Test
     public void TestGetFrom(){
         MessageActionsPayloadFrom from = new MessageActionsPayloadFrom();
@@ -172,6 +214,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, from);
     }
 
+    /**
+     * Ensures that the Body property can be set and retrieved.
+     */
     @Test
     public void TestGetBody(){
         MessageActionsPayloadBody body = new MessageActionsPayloadBody();
@@ -185,6 +230,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, body);
     }
 
+    /**
+     * Ensures that the AttachmentLayout property can be set and retrieved.
+     */
     @Test
     public void TestGetAttachmentLayout(){
         String attachmentLayout = "testAttachmentLayout";
@@ -198,6 +246,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, attachmentLayout);
     }
 
+    /**
+     * Ensures that the Attachments property can be set and retrieved.
+     */
     @Test
     public void TestGetAttachments(){
         List<MessageActionsPayloadAttachment> attachments = new ArrayList<MessageActionsPayloadAttachment>();
@@ -211,6 +262,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, attachments);
     }
 
+    /**
+     * Ensures that the Mentions property can be set and retrieved.
+     */
     @Test
     public void TestGetMentions(){
         List<MessageActionsPayloadMention> mentions = new ArrayList<MessageActionsPayloadMention>();
@@ -224,6 +278,9 @@ public class MessageActionsPayloadTest {
         Assert.assertEquals(result, mentions);
     }
 
+    /**
+     * Ensures that the Reactions property can be set and retrieved.
+     */
     @Test
     public void TestGetReactions(){
         List<MessageActionsPayloadReaction> reactions = new ArrayList<MessageActionsPayloadReaction>();

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/teams/MessageActionsPayloadTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/teams/MessageActionsPayloadTest.java
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.bot.schema.teams;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MessageActionsPayloadTest {
+    @Test
+    public void TestMessageActionPayloadConstructor(){
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        Assert.assertNotNull(messageActionsPayload);
+    }
+
+    @Test
+    public void TestGetId(){
+        String id = "testId";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setId(id);
+            }
+        };
+        String result = messageActionsPayload.getId();
+
+        Assert.assertEquals(result, id);
+    }
+
+    @Test
+    public void TestGetReplyToId(){
+        String replyToId = "testReplyToId";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setReplyToId(replyToId);
+            }
+        };
+        String result = messageActionsPayload.getReplyToId();
+
+        Assert.assertEquals(result, replyToId);
+    }
+
+    @Test
+    public void TestGetMessageType(){
+        String messageType = "testMessageType";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setMessageType(messageType);
+            }
+        };
+        String result = messageActionsPayload.getMessageType();
+
+        Assert.assertEquals(result, messageType);
+    }
+
+    @Test
+    public void TestGetCreatedDateTime(){
+        String createdDateTime = "2000-01-01";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setCreatedDateTime(createdDateTime);
+            }
+        };
+        String result = messageActionsPayload.getCreatedDateTime();
+
+        Assert.assertEquals(result, createdDateTime);
+    }
+
+    @Test
+    public void TestGetLastModifiedDateTime(){
+        String lastModifiedDateTime = "2000-01-01";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setLastModifiedDateTime(lastModifiedDateTime);
+            }
+        };
+        String result = messageActionsPayload.getLastModifiedDateTime();
+
+        Assert.assertEquals(result, lastModifiedDateTime);
+    }
+
+    @Test
+    public void TestGetDeleted(){
+        Boolean deleted = false;
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setDeleted(deleted);
+            }
+        };
+        Boolean result = messageActionsPayload.getDeleted();
+
+        Assert.assertEquals(result, deleted);
+    }
+
+    @Test
+    public void TestGetSubject(){
+        String subject = "testSubject";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setSubject(subject);
+            }
+        };
+        String result = messageActionsPayload.getSubject();
+
+        Assert.assertEquals(result, subject);
+    }
+
+    @Test
+    public void TestGetSummary(){
+        String summary = "testSummary";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setSummary(summary);
+            }
+        };
+        String result = messageActionsPayload.getSummary();
+
+        Assert.assertEquals(result, summary);
+    }
+
+    @Test
+    public void TestGetImportance(){
+        String importance = "normal";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setImportance(importance);
+            }
+        };
+        String result = messageActionsPayload.getImportance();
+
+        Assert.assertEquals(result, importance);
+    }
+
+    @Test
+    public void TestGetLinkToMessage(){
+        String linkToMessage = "https://teams.microsoft.com/l/message/testing-id";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setLinkToMessage(linkToMessage);
+            }
+        };
+        String result = messageActionsPayload.getLinkToMessage();
+
+        Assert.assertEquals(result, linkToMessage);
+    }
+
+    @Test
+    public void TestGetLocale(){
+        String locale = "US";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setLocale(locale);
+            }
+        };
+        String result = messageActionsPayload.getLocale();
+
+        Assert.assertEquals(result, locale);
+    }
+
+    @Test
+    public void TestGetFrom(){
+        MessageActionsPayloadFrom from = new MessageActionsPayloadFrom();
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setFrom(from);
+            }
+        };
+        MessageActionsPayloadFrom result = messageActionsPayload.getFrom();
+
+        Assert.assertEquals(result, from);
+    }
+
+    @Test
+    public void TestGetBody(){
+        MessageActionsPayloadBody body = new MessageActionsPayloadBody();
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setBody(body);
+            }
+        };
+        MessageActionsPayloadBody result = messageActionsPayload.getBody();
+
+        Assert.assertEquals(result, body);
+    }
+
+    @Test
+    public void TestGetAttachmentLayout(){
+        String attachmentLayout = "testAttachmentLayout";
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setAttachmentLayout(attachmentLayout);
+            }
+        };
+        String result = messageActionsPayload.getAttachmentLayout();
+
+        Assert.assertEquals(result, attachmentLayout);
+    }
+
+    @Test
+    public void TestGetAttachments(){
+        List<MessageActionsPayloadAttachment> attachments = new ArrayList<MessageActionsPayloadAttachment>();
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setAttachments(attachments);
+            }
+        };
+        List<MessageActionsPayloadAttachment> result = messageActionsPayload.getAttachments();
+
+        Assert.assertEquals(result, attachments);
+    }
+
+    @Test
+    public void TestGetMentions(){
+        List<MessageActionsPayloadMention> mentions = new ArrayList<MessageActionsPayloadMention>();
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setMentions(mentions);
+            }
+        };
+        List<MessageActionsPayloadMention> result = messageActionsPayload.getMentions();
+
+        Assert.assertEquals(result, mentions);
+    }
+
+    @Test
+    public void TestGetReactions(){
+        List<MessageActionsPayloadReaction> reactions = new ArrayList<MessageActionsPayloadReaction>();
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
+            {
+                setReactions(reactions);
+            }
+        };
+        List<MessageActionsPayloadReaction> result = messageActionsPayload.getReactions();
+
+        Assert.assertEquals(result, reactions);
+    }
+}


### PR DESCRIPTION
Fixes #622
## Description
This pull request adds the `linkToMessage` property to the `MessageActionsPayload` class from BotBuilder-Schema library. By adding this property, it can add the link provided in the payload from MS-Teams.
Also, we added tests for the methods of the class.

## Specific Changes
- Added the `linkToMessage` property to the `MessageActionsPayload` class from BotBuilder-Schema
- Created the `MessageActionsPayloadTest.java` file inside the `test/teams` folder of the library.
- Added tests for all the methods of the `MessageActionsPayload` in that test class.

 ## Testing
In the following image, you can see the bot assigns the `linkToMessage` property when sharing a card in MS-Teams, using the `51.teams-messaging-extensions-action` sample from the same repository.
![image](https://user-images.githubusercontent.com/38112957/85457505-82982980-b576-11ea-8837-784319684a3d.png)

And in the next image, you can see the added tests passing.
![image](https://user-images.githubusercontent.com/38112957/85457557-904daf00-b576-11ea-9927-8fe428a93ad3.png)
