### PR TITLE
Add Teams' Channel Restored event

### DIFF
--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
@@ -233,7 +233,8 @@ public class TeamsActivityHandler extends ActivityHandler {
      * Invoked when a file consent card activity is received from the connector.
      *
      * @param turnContext The current TurnContext.
-     * @param fileConsentCardResponse The response representing the value of the invoke activity sent when the user acts on a file consent card.
+     * @param fileConsentCardResponse The response representing the value of the invoke activity sent
+     * when the user acts on a file consent card.
      * @return An InvokeResponse depending on the action of the file consent card.
      */
     protected CompletableFuture<InvokeResponse> onTeamsFileConsent(
@@ -267,7 +268,8 @@ public class TeamsActivityHandler extends ActivityHandler {
      * Invoked when a file consent card is accepted by the user.
      *
      * @param turnContext The current TurnContext.
-     * @param fileConsentCardResponse The response representing the value of the invoke activity sent when the user accepts a file consent card.
+     * @param fileConsentCardResponse The response representing the value of the invoke activity sent
+     * when the user accepts a file consent card.
      * @return A task that represents the work queued to execute.
      */
     protected CompletableFuture<Void> onTeamsFileConsentAccept(
@@ -281,7 +283,8 @@ public class TeamsActivityHandler extends ActivityHandler {
      * Invoked when a file consent card is declined by the user.
      *
      * @param turnContext The current TurnContext.
-     * @param fileConsentCardResponse The response representing the value of the invoke activity sent when the user declines a file consent card.
+     * @param fileConsentCardResponse The response representing the value of the invoke activity sent
+     * when the user declines a file consent card.
      * @return A task that represents the work queued to execute.
      */
     protected CompletableFuture<Void> onTeamsFileConsentDecline(
@@ -510,7 +513,8 @@ public class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Invoked when a conversation update activity is received from the channel.
-     * Conversation update activities are useful when it comes to responding to users being added to or removed from the channel.
+     * Conversation update activities are useful when it comes to responding to users being added to
+     * or removed from the channel.
      * For example, a bot could respond to a user being added by greeting the user.
      *
      * @param turnContext The current TurnContext.
@@ -624,7 +628,8 @@ public class TeamsActivityHandler extends ActivityHandler {
      * join the channel, such as your bot's welcome logic.
      * It will get the associated members with the provided accounts.
      *
-     * @param membersAdded A list of all the accounts added to the channel, as described by the conversation update activity.
+     * @param membersAdded A list of all the accounts added to the channel, as described by
+     * the conversation update activity.
      * @param teamInfo The team info object representing the team.
      * @param turnContext The current TurnContext.
      * @return A task that represents the work queued to execute.
@@ -691,7 +696,8 @@ public class TeamsActivityHandler extends ActivityHandler {
      * leave the channel, such as your bot's good-bye logic.
      * It will get the associated members with the provided accounts.
      *
-     * @param membersRemoved A list of all the accounts removed from the channel, as described by the conversation update activity.
+     * @param membersRemoved A list of all the accounts removed from the channel, as described by
+     * the conversation update activity.
      * @param teamInfo The team info object representing the team.
      * @param turnContext The current TurnContext.
      * @return A task that represents the work queued to execute.
@@ -721,7 +727,8 @@ public class TeamsActivityHandler extends ActivityHandler {
      * Override this in a derived class to provide logic for when members other than the bot
      * join the channel, such as your bot's welcome logic.
      *
-     * @param membersAdded A list of all the members added to the channel, as described by the conversation update activity.
+     * @param membersAdded A list of all the members added to the channel, as described by
+     * the conversation update activity.
      * @param teamInfo The team info object representing the team.
      * @param turnContext The current TurnContext.
      * @return A task that represents the work queued to execute.
@@ -738,7 +745,8 @@ public class TeamsActivityHandler extends ActivityHandler {
      * Override this in a derived class to provide logic for when members other than the bot
      * leave the channel, such as your bot's good-bye logic.
      *
-     * @param membersRemoved A list of all the members removed from the channel, as described by the conversation update activity.
+     * @param membersRemoved A list of all the members removed from the channel, as described by
+     * the conversation update activity.
      * @param teamInfo The team info object representing the team.
      * @param turnContext The current TurnContext.
      * @return A task that represents the work queued to execute.

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
@@ -200,7 +200,7 @@ public class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Invoked when an card action invoke activity is received from the connector.
+     * Invoked when a card action invoke activity is received from the connector.
      *
      * @param turnContext The current TurnContext.
      * @return A task that represents the work queued to execute.
@@ -278,7 +278,7 @@ public class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Invoked when a file consent card is accepted by the user.
+     * Invoked when a file consent card is declined by the user.
      *
      * @param turnContext The current TurnContext.
      * @param fileConsentCardResponse The response representing the value of the invoke activity sent when the user declines a file consent card.
@@ -457,7 +457,7 @@ public class TeamsActivityHandler extends ActivityHandler {
      *
      * @param turnContext The current TurnContext.
      * @param settings Object representing the configuration settings.
-     * @return The Messaging Extension Response for the query.
+     * @return A task that represents the work queued to execute.
      */
     protected CompletableFuture<Void> onTeamsMessagingExtensionConfigurationSetting(
         TurnContext turnContext,
@@ -587,7 +587,7 @@ public class TeamsActivityHandler extends ActivityHandler {
     /**
      * Override this in a derived class to provide logic for when members other than the bot
      * join the channel, such as your bot's welcome logic.
-     * UseIt will get the associated members with the provided accounts.
+     * It will get the associated members with the provided accounts.
      *
      * @param membersAdded A list of all the accounts added to the channel, as described by the conversation update activity.
      * @param teamInfo The team info object representing the team.

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
@@ -416,6 +416,13 @@ public class TeamsActivityHandler extends ActivityHandler {
                             turnContext
                         );
 
+                    case "channelRestored":
+                        return onTeamsChannelRestored(
+                            channelData.value().getChannel(),
+                            channelData.value().getTeam(),
+                            turnContext
+                        );
+
                     case "teamRenamed":
                         return onTeamsTeamRenamed(
                             channelData.value().getChannel(),
@@ -543,6 +550,14 @@ public class TeamsActivityHandler extends ActivityHandler {
     }
 
     protected CompletableFuture<Void> onTeamsChannelRenamed(
+        ChannelInfo channelInfo,
+        TeamInfo teamInfo,
+        TurnContext turnContext
+    ) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    protected CompletableFuture<Void> onTeamsChannelRestored(
         ChannelInfo channelInfo,
         TeamInfo teamInfo,
         TurnContext turnContext

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
@@ -199,18 +199,43 @@ public class TeamsActivityHandler extends ActivityHandler {
         });
     }
 
+    /**
+     * Invoked when an card action invoke activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<InvokeResponse> onTeamsCardActionInvoke(TurnContext turnContext) {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a signIn invoke activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onSignInInvoke(TurnContext turnContext) {
         return onTeamsSigninVerifyState(turnContext);
     }
 
+    /**
+     * Invoked when a signIn verify state activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsSigninVerifyState(TurnContext turnContext) {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a file consent card activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param fileConsentCardResponse The response representing the value of the invoke activity sent when the user acts on a file consent card.
+     * @return An InvokeResponse depending on the action of the file consent card.
+     */
     protected CompletableFuture<InvokeResponse> onTeamsFileConsent(
         TurnContext turnContext,
         FileConsentCardResponse fileConsentCardResponse
@@ -238,6 +263,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         }
     }
 
+    /**
+     * Invoked when a file consent card is accepted by the user.
+     *
+     * @param turnContext The current TurnContext.
+     * @param fileConsentCardResponse The response representing the value of the invoke activity sent when the user accepts a file consent card.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsFileConsentAccept(
         TurnContext turnContext,
         FileConsentCardResponse fileConsentCardResponse
@@ -245,6 +277,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a file consent card is accepted by the user.
+     *
+     * @param turnContext The current TurnContext.
+     * @param fileConsentCardResponse The response representing the value of the invoke activity sent when the user declines a file consent card.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsFileConsentDecline(
         TurnContext turnContext,
         FileConsentCardResponse fileConsentCardResponse
@@ -252,6 +291,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a Messaging Extension Query activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param query The query for the search command.
+     * @return The Messaging Extension Response for the query.
+     */
     protected CompletableFuture<MessagingExtensionResponse> onTeamsMessagingExtensionQuery(
         TurnContext turnContext,
         MessagingExtensionQuery query
@@ -259,6 +305,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a O365 Connector Card Action activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param query The O365 connector card HttpPOST invoke query.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsO365ConnectorCardAction(
         TurnContext turnContext,
         O365ConnectorCardActionQuery query
@@ -266,6 +319,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when an app based link query activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param query The invoke request body type for app-based link query.
+     * @return The Messaging Extension Response for the query.
+     */
     protected CompletableFuture<MessagingExtensionResponse> onTeamsAppBasedLinkQuery(
         TurnContext turnContext,
         AppBasedLinkQuery query
@@ -273,6 +333,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a messaging extension select item activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param query The object representing the query.
+     * @return The Messaging Extension Response for the query.
+     */
     protected CompletableFuture<MessagingExtensionResponse> onTeamsMessagingExtensionSelectItem(
         TurnContext turnContext,
         Object query
@@ -280,6 +347,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a Messaging Extension Fetch activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param action The messaging extension action.
+     * @return The Messaging Extension Action Response for the action.
+     */
     protected CompletableFuture<MessagingExtensionActionResponse> onTeamsMessagingExtensionFetchTask(
         TurnContext turnContext,
         MessagingExtensionAction action
@@ -287,6 +361,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a messaging extension submit action dispatch activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param action The messaging extension action.
+     * @return The Messaging Extension Action Response for the action.
+     */
     protected CompletableFuture<MessagingExtensionActionResponse> onTeamsMessagingExtensionSubmitActionDispatch(
         TurnContext turnContext,
         MessagingExtensionAction action
@@ -315,6 +396,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         }
     }
 
+    /**
+     * Invoked when a messaging extension submit action activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param action The messaging extension action.
+     * @return The Messaging Extension Action Response for the action.
+     */
     protected CompletableFuture<MessagingExtensionActionResponse> onTeamsMessagingExtensionSubmitAction(
         TurnContext turnContext,
         MessagingExtensionAction action
@@ -322,6 +410,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a messaging extension bot message preview edit activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param action The messaging extension action.
+     * @return The Messaging Extension Action Response for the action.
+     */
     protected CompletableFuture<MessagingExtensionActionResponse> onTeamsMessagingExtensionBotMessagePreviewEdit(
         TurnContext turnContext,
         MessagingExtensionAction action
@@ -329,6 +424,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a messaging extension bot message preview send activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param action The messaging extension action.
+     * @return The Messaging Extension Action Response for the action.
+     */
     protected CompletableFuture<MessagingExtensionActionResponse> onTeamsMessagingExtensionBotMessagePreviewSend(
         TurnContext turnContext,
         MessagingExtensionAction action
@@ -336,6 +438,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a messaging extension configuration query setting url activity is received from the connector.
+     *
+     * @param turnContext The current TurnContext.
+     * @param query The Messaging extension query.
+     * @return The Messaging Extension Response for the query.
+     */
     protected CompletableFuture<MessagingExtensionResponse> onTeamsMessagingExtensionConfigurationQuerySettingUrl(
         TurnContext turnContext,
         MessagingExtensionQuery query
@@ -343,6 +452,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Override this in a derived class to provide logic for when a configuration is set for a messaging extension.
+     *
+     * @param turnContext The current TurnContext.
+     * @param settings Object representing the configuration settings.
+     * @return The Messaging Extension Response for the query.
+     */
     protected CompletableFuture<Void> onTeamsMessagingExtensionConfigurationSetting(
         TurnContext turnContext,
         Object settings
@@ -350,6 +466,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Override this in a derived class to provide logic for when a task module is fetched.
+     *
+     * @param turnContext The current TurnContext.
+     * @param taskModuleRequest The task module invoke request value payload.
+     * @return A Task Module Response for the request.
+     */
     protected CompletableFuture<TaskModuleResponse> onTeamsTaskModuleFetch(
         TurnContext turnContext,
         TaskModuleRequest taskModuleRequest
@@ -357,6 +480,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Override this in a derived class to provide logic for when a card button is clicked in a messaging extension.
+     *
+     * @param turnContext The current TurnContext.
+     * @param cardData Object representing the card data.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsMessagingExtensionCardButtonClicked(
         TurnContext turnContext,
         Object cardData
@@ -364,6 +494,13 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Override this in a derived class to provide logic for when a task module is submited.
+     *
+     * @param turnContext The current TurnContext.
+     * @param taskModuleRequest The task module invoke request value payload.
+     * @return A Task Module Response for the request.
+     */
     protected CompletableFuture<TaskModuleResponse> onTeamsTaskModuleSubmit(
         TurnContext turnContext,
         TaskModuleRequest taskModuleRequest
@@ -371,6 +508,14 @@ public class TeamsActivityHandler extends ActivityHandler {
         return notImplemented();
     }
 
+    /**
+     * Invoked when a conversation update activity is received from the channel.
+     * Conversation update activities are useful when it comes to responding to users being added to or removed from the channel.
+     * For example, a bot could respond to a user being added by greeting the user.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onConversationUpdateActivity(TurnContext turnContext) {
         if (turnContext.getActivity().isTeamsActivity()) {
             ResultPair<TeamsChannelData> channelData = turnContext.getActivity().tryGetChannelData(
@@ -439,6 +584,16 @@ public class TeamsActivityHandler extends ActivityHandler {
         return super.onConversationUpdateActivity(turnContext);
     }
 
+    /**
+     * Override this in a derived class to provide logic for when members other than the bot
+     * join the channel, such as your bot's welcome logic.
+     * UseIt will get the associated members with the provided accounts.
+     *
+     * @param membersAdded A list of all the accounts added to the channel, as described by the conversation update activity.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsMembersAddedDispatch(
         List<ChannelAccount> membersAdded,
         TeamInfo teamInfo,
@@ -496,6 +651,16 @@ public class TeamsActivityHandler extends ActivityHandler {
         return onTeamsMembersAdded(teamsMembersAdded, teamInfo, turnContext);
     }
 
+    /**
+     * Override this in a derived class to provide logic for when members other than the bot
+     * leave the channel, such as your bot's good-bye logic.
+     * It will get the associated members with the provided accounts.
+     *
+     * @param membersRemoved A list of all the accounts removed from the channel, as described by the conversation update activity.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsMembersRemovedDispatch(
         List<ChannelAccount> membersRemoved,
         TeamInfo teamInfo,
@@ -517,6 +682,15 @@ public class TeamsActivityHandler extends ActivityHandler {
         return onTeamsMembersRemoved(teamsMembersRemoved, teamInfo, turnContext);
     }
 
+    /**
+     * Override this in a derived class to provide logic for when members other than the bot
+     * join the channel, such as your bot's welcome logic.
+     *
+     * @param membersAdded A list of all the members added to the channel, as described by the conversation update activity.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsMembersAdded(
         List<TeamsChannelAccount> membersAdded,
         TeamInfo teamInfo,
@@ -525,6 +699,15 @@ public class TeamsActivityHandler extends ActivityHandler {
         return onMembersAdded(new ArrayList<>(membersAdded), turnContext);
     }
 
+    /**
+     * Override this in a derived class to provide logic for when members other than the bot
+     * leave the channel, such as your bot's good-bye logic.
+     *
+     * @param membersRemoved A list of all the members removed from the channel, as described by the conversation update activity.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsMembersRemoved(
         List<TeamsChannelAccount> membersRemoved,
         TeamInfo teamInfo,
@@ -533,6 +716,15 @@ public class TeamsActivityHandler extends ActivityHandler {
         return onMembersRemoved(new ArrayList<>(membersRemoved), turnContext);
     }
 
+    /**
+     * Invoked when a Channel Created event activity is received from the connector.
+     * Channel Created correspond to the user creating a new channel.
+     *
+     * @param channelInfo The channel info object which describes the channel.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsChannelCreated(
         ChannelInfo channelInfo,
         TeamInfo teamInfo,
@@ -541,6 +733,15 @@ public class TeamsActivityHandler extends ActivityHandler {
         return CompletableFuture.completedFuture(null);
     }
 
+    /**
+     * Invoked when a Channel Deleted event activity is received from the connector.
+     * Channel Deleted correspond to the user deleting an existing channel.
+     *
+     * @param channelInfo The channel info object which describes the channel.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsChannelDeleted(
         ChannelInfo channelInfo,
         TeamInfo teamInfo,
@@ -549,6 +750,15 @@ public class TeamsActivityHandler extends ActivityHandler {
         return CompletableFuture.completedFuture(null);
     }
 
+    /**
+     * Invoked when a Channel Renamed event activity is received from the connector.
+     * Channel Renamed correspond to the user renaming an existing channel.
+     *
+     * @param channelInfo The channel info object which describes the channel.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsChannelRenamed(
         ChannelInfo channelInfo,
         TeamInfo teamInfo,
@@ -557,6 +767,15 @@ public class TeamsActivityHandler extends ActivityHandler {
         return CompletableFuture.completedFuture(null);
     }
 
+    /**
+     * Invoked when a Channel Restored event activity is received from the connector.
+     * Channel Restored correspond to the user restoring a previously deleted channel.
+     *
+     * @param channelInfo The channel info object which describes the channel.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsChannelRestored(
         ChannelInfo channelInfo,
         TeamInfo teamInfo,
@@ -565,6 +784,15 @@ public class TeamsActivityHandler extends ActivityHandler {
         return CompletableFuture.completedFuture(null);
     }
 
+    /**
+     * Invoked when a Team Renamed event activity is received from the connector.
+     * Team Renamed correspond to the user renaming an existing team.
+     *
+     * @param channelInfo The channel info object which describes the channel.
+     * @param teamInfo The team info object representing the team.
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
     protected CompletableFuture<Void> onTeamsTeamRenamed(
         ChannelInfo channelInfo,
         TeamInfo teamInfo,
@@ -573,10 +801,21 @@ public class TeamsActivityHandler extends ActivityHandler {
         return CompletableFuture.completedFuture(null);
     }
 
+    /**
+     * Invoke a new InvokeResponseException with a HTTP 501 code status.
+     *
+     * @return true if this invocation caused this CompletableFuture to transition to a completed state, else false
+     */
     protected <T> CompletableFuture<T> notImplemented() {
         return notImplemented(null);
     }
 
+    /**
+     * Invoke a new InvokeResponseException with a HTTP 501 code status.
+     *
+     * @param body The body for the InvokeResponseException.
+     * @return true if this invocation caused this CompletableFuture to transition to a completed state, else false
+     */
     protected <T> CompletableFuture<T> notImplemented(String body) {
         CompletableFuture<T> result = new CompletableFuture<>();
         result.completeExceptionally(
@@ -585,6 +824,12 @@ public class TeamsActivityHandler extends ActivityHandler {
         return result;
     }
 
+    /**
+     * Error handler that can catch exceptions.
+     *
+     * @param t The exception thrown.
+     * @return A task that represents the work queued to execute.
+     */
     protected <T> CompletableFuture<T> withException(Throwable t) {
         CompletableFuture<T> result = new CompletableFuture<>();
         result.completeExceptionally(new CompletionException(t));

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java
@@ -315,6 +315,29 @@ public class TeamsActivityHandlerTests {
     }
 
     @Test
+    public void TestConversationUpdateTeamsChannelRestored() {
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
+            {
+                setChannelData(new TeamsChannelData() {
+                    {
+                        setEventType("channelRestored");
+                    }
+                });
+                setChannelId(Channels.MSTEAMS);
+            }
+        };
+
+        TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
+
+        TestActivityHandler bot = new TestActivityHandler();
+        bot.onTurn(turnContext).join();
+
+        Assert.assertEquals(2, bot.record.size());
+        Assert.assertEquals("onConversationUpdateActivity", bot.record.get(0));
+        Assert.assertEquals("onTeamsChannelRestored", bot.record.get(1));
+    }
+
+    @Test
     public void TestConversationUpdateTeamsTeamRenamed() {
         Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
             {
@@ -1160,6 +1183,16 @@ public class TeamsActivityHandlerTests {
         ) {
             record.add("onTeamsChannelRenamed");
             return super.onTeamsChannelRenamed(channelInfo, teamInfo, turnContext);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onTeamsChannelRestored(
+            ChannelInfo channelInfo,
+            TeamInfo teamInfo,
+            TurnContext turnContext
+        ) {
+            record.add("onTeamsChannelRestored");
+            return super.onTeamsChannelRestored(channelInfo, teamInfo, turnContext);
         }
 
         @Override


### PR DESCRIPTION
Fixes #611

## Description
Adds the MS-Teams' event _channelRestored_ to the [TeamsActivityHandler](https://github.com/microsoft/botbuilder-java/blob/master/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java) class.

## Specific Changes
- Updated [TeamsActivityHandler](https://github.com/microsoft/botbuilder-java/blob/master/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java) class to add the new **OnTeamsChannelRestoredEvent** method.
- Add unit test for the new method in the [TeamsActivityHandlerTests](https://github.com/microsoft/botbuilder-java/blob/master/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java) class.

## Testing
Below you can see a bot using the _channelRestored_ event, adapted to send a message when the event is raised and in the last image with the test passing.
![image](https://user-images.githubusercontent.com/62260472/86290916-a1c13780-bbc4-11ea-8b60-a5a024102ecb.png)
![image](https://user-images.githubusercontent.com/62260472/86290883-9241ee80-bbc4-11ea-9cc6-c8be989c741d.png)