### PR TITLE
Changed Maven to execute tests matching *Test*.java

### DIFF
--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsInfoTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsInfoTests.java
@@ -43,7 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TeamsInfoTests {
     @Test
     public void TestSendMessageToTeamsChannel() {

--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,9 @@
           <configuration>
             <source>${jdk.version}</source>
             <target>${jdk.version}</target>
+            <compilerArgs>
+              <arg>-Xpkginfo:always</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>
@@ -439,6 +442,17 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+          <configuration>
+            <includes>
+              <include>**/*Test*.java</include>
+            </includes>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Fixes #766 

Also corrected compile to produce a class file for package-info to allow incremental builds to work correctly.  By default, nothing is produced for this empty file, which would trigger "changes detected" each build.