### PR TITLE
Sample deploy improvements

### DIFF
--- a/samples/02.echo-bot/README.md
+++ b/samples/02.echo-bot/README.md
@@ -59,23 +59,18 @@ Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` 
 #### To an existing Resource Group
 `az group deployment create --name "echoBotDeploy" --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="<botname>" appId="<appid>" appSecret="<appsecret>"`
 
-### 5. Update the pom.xml
-In pom.xml update the following nodes under azure-webapp-maven-plugin
-- `resourceGroup` using the `<groupname>` used above
-- `appName` using the `<botname>` used above
-
-### 6. Update app id and password
+### 5. Update app id and password
 In src/main/resources/application.properties update 
   - `MicrosoftAppPassword` with the botsecret value
   - `MicrosoftAppId` with the appid from the first step
 
-### 7. Deploy the code
+### 6. Deploy the code
 - Execute `mvn clean package` 
-- Execute `mvn azure-webapp:deploy`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<botname>"`
 
 If the deployment is successful, you will be able to test it via "Test in Web Chat" from the Azure Portal using the "Bot Channel Registration" for the bot.
 
-After the bot is deployed, you only need to execute #7 if you make changes to the bot.
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 
 ## Further reading

--- a/samples/02.echo-bot/pom.xml
+++ b/samples/02.echo-bot/pom.xml
@@ -143,8 +143,8 @@
                   <version>1.7.0</version>
                   <configuration>
                       <schemaVersion>V2</schemaVersion>
-                      <resourceGroup>{groupname}</resourceGroup>
-                      <appName>{botname}</appName>
+                      <resourceGroup>${groupname}</resourceGroup>
+                      <appName>${botname}</appName>
                       <appSettings>
                           <property>
                               <name>JAVA_OPTS</name>

--- a/samples/03.welcome-user/README.md
+++ b/samples/03.welcome-user/README.md
@@ -59,23 +59,18 @@ Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` 
 #### To an existing Resource Group
 `az group deployment create --name "stateBotDeploy" --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="<botname>" appId="<appid>" appSecret="<appsecret>"`
 
-### 5. Update the pom.xml
-In pom.xml update the following nodes under azure-webapp-maven-plugin
-- `resourceGroup` using the `<groupname>` used above
-- `appName` using the `<botname>` used above
-
-### 6. Update app id and password
+### 5. Update app id and password
 In src/main/resources/application.properties update 
   - `MicrosoftAppPassword` with the botsecret value
   - `MicrosoftAppId` with the appid from the first step
 
-### 7. Deploy the code
+### 6. Deploy the code
 - Execute `mvn clean package` 
-- Execute `mvn azure-webapp:deploy`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<botname>"`
 
 If the deployment is successful, you will be able to test it via "Test in Web Chat" from the Azure Portal using the "Bot Channel Registration" for the bot.
 
-After the bot is deployed, you only need to execute #7 if you make changes to the bot.
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 
 ## Further reading

--- a/samples/03.welcome-user/pom.xml
+++ b/samples/03.welcome-user/pom.xml
@@ -143,8 +143,8 @@
                   <version>1.7.0</version>
                   <configuration>
                       <schemaVersion>V2</schemaVersion>
-                      <resourceGroup>{groupname}</resourceGroup>
-                      <appName>{botname}</appName>
+                      <resourceGroup>${groupname}</resourceGroup>
+                      <appName>${botname}</appName>
                       <appSettings>
                           <property>
                               <name>JAVA_OPTS</name>

--- a/samples/08.suggested-actions/README.md
+++ b/samples/08.suggested-actions/README.md
@@ -59,23 +59,18 @@ Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` 
 #### To an existing Resource Group
 `az group deployment create --name "echoBotDeploy" --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="<botname>" appId="<appid>" appSecret="<appsecret>"`
 
-### 5. Update the pom.xml
-In pom.xml update the following nodes under azure-webapp-maven-plugin
-- `resourceGroup` using the `<groupname>` used above
-- `appName` using the `<botname>` used above
-
-### 6. Update app id and password
+### 5. Update app id and password
 In src/main/resources/application.properties update 
   - `MicrosoftAppPassword` with the botsecret value
   - `MicrosoftAppId` with the appid from the first step
 
-### 7. Deploy the code
+### 6. Deploy the code
 - Execute `mvn clean package` 
-- Execute `mvn azure-webapp:deploy`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<botname>"`
 
 If the deployment is successful, you will be able to test it via "Test in Web Chat" from the Azure Portal using the "Bot Channel Registration" for the bot.
 
-After the bot is deployed, you only need to execute #7 if you make changes to the bot.
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 
 ## Further reading

--- a/samples/08.suggested-actions/pom.xml
+++ b/samples/08.suggested-actions/pom.xml
@@ -143,8 +143,8 @@
                   <version>1.7.0</version>
                   <configuration>
                       <schemaVersion>V2</schemaVersion>
-                      <resourceGroup>{groupname}</resourceGroup>
-                      <appName>{botname}</appName>
+                      <resourceGroup>${groupname}</resourceGroup>
+                      <appName>${botname}</appName>
                       <appSettings>
                           <property>
                               <name>JAVA_OPTS</name>

--- a/samples/16.proactive-messages/README.md
+++ b/samples/16.proactive-messages/README.md
@@ -68,23 +68,18 @@ Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` 
 #### To an existing Resource Group
 `az group deployment create --name "echoBotDeploy" --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="<botname>" appId="<appid>" appSecret="<appsecret>"`
 
-### 5. Update the pom.xml
-In pom.xml update the following nodes under azure-webapp-maven-plugin
-- `resourceGroup` using the `<groupname>` used above
-- `appName` using the `<botname>` used above
-
-### 6. Update app id and password
+### 5. Update app id and password
 In src/main/resources/application.properties update 
   - `MicrosoftAppPassword` with the botsecret value
   - `MicrosoftAppId` with the appid from the first step
 
-### 7. Deploy the code
+### 6. Deploy the code
 - Execute `mvn clean package` 
-- Execute `mvn azure-webapp:deploy`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<botname>"`
 
 If the deployment is successful, you will be able to test it via "Test in Web Chat" from the Azure Portal using the "Bot Channel Registration" for the bot.
 
-After the bot is deployed, you only need to execute #7 if you make changes to the bot.
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 
 ## Further reading

--- a/samples/16.proactive-messages/pom.xml
+++ b/samples/16.proactive-messages/pom.xml
@@ -143,8 +143,8 @@
                   <version>1.7.0</version>
                   <configuration>
                       <schemaVersion>V2</schemaVersion>
-                      <resourceGroup>{groupname}</resourceGroup>
-                      <appName>{botname}</appName>
+                      <resourceGroup>${groupname}</resourceGroup>
+                      <appName>${botname}</appName>
                       <appSettings>
                           <property>
                               <name>JAVA_OPTS</name>

--- a/samples/45.state-management/README.md
+++ b/samples/45.state-management/README.md
@@ -62,23 +62,18 @@ Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` 
 #### To an existing Resource Group
 `az group deployment create --name "stateBotDeploy" --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="<botname>" appId="<appid>" appSecret="<appsecret>"`
 
-### 5. Update the pom.xml
-In pom.xml update the following nodes under azure-webapp-maven-plugin
-- `resourceGroup` using the `<groupname>` used above
-- `appName` using the `<botname>` used above
-
-### 6. Update app id and password
+### 5. Update app id and password
 In src/main/resources/application.properties update 
   - `MicrosoftAppPassword` with the botsecret value
   - `MicrosoftAppId` with the appid from the first step
 
-### 7. Deploy the code
+### 6. Deploy the code
 - Execute `mvn clean package` 
-- Execute `mvn azure-webapp:deploy`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<botname>"`
 
 If the deployment is successful, you will be able to test it via "Test in Web Chat" from the Azure Portal using the "Bot Channel Registration" for the bot.
 
-After the bot is deployed, you only need to execute #7 if you make changes to the bot.
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 
 ## Further reading

--- a/samples/45.state-management/pom.xml
+++ b/samples/45.state-management/pom.xml
@@ -142,8 +142,8 @@
                   <version>1.7.0</version>
                   <configuration>
                       <schemaVersion>V2</schemaVersion>
-                      <resourceGroup>{groupname}</resourceGroup>
-                      <appName>{botname}</appName>
+                      <resourceGroup>${groupname}</resourceGroup>
+                      <appName>${botname}</appName>
                       <appSettings>
                           <property>
                               <name>JAVA_OPTS</name>

--- a/samples/47.inspection/README.md
+++ b/samples/47.inspection/README.md
@@ -74,23 +74,18 @@ Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` 
 #### To an existing Resource Group
 `az group deployment create --name "echoBotDeploy" --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="<botname>" appId="<appid>" appSecret="<appsecret>"`
 
-### 5. Update the pom.xml
-In pom.xml update the following nodes under azure-webapp-maven-plugin
-- `resourceGroup` using the `<groupname>` used above
-- `appName` using the `<botname>` used above
-
-### 6. Update app id and password
+### 5. Update app id and password
 In src/main/resources/application.properties update 
   - `MicrosoftAppPassword` with the botsecret value
   - `MicrosoftAppId` with the appid from the first step
 
-### 7. Deploy the code
+### 6. Deploy the code
 - Execute `mvn clean package` 
-- Execute `mvn azure-webapp:deploy`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<botname>"`
 
 If the deployment is successful, you will be able to test it via "Test in Web Chat" from the Azure Portal using the "Bot Channel Registration" for the bot.
 
-After the bot is deployed, you only need to execute #7 if you make changes to the bot.
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 
 ## Further reading

--- a/samples/47.inspection/pom.xml
+++ b/samples/47.inspection/pom.xml
@@ -143,8 +143,8 @@
                   <version>1.7.0</version>
                   <configuration>
                       <schemaVersion>V2</schemaVersion>
-                      <resourceGroup>{groupname}</resourceGroup>
-                      <appName>{botname}</appName>
+                      <resourceGroup>${groupname}</resourceGroup>
+                      <appName>${botname}</appName>
                       <appSettings>
                           <property>
                               <name>JAVA_OPTS</name>

--- a/samples/servlet-echo/README.md
+++ b/samples/servlet-echo/README.md
@@ -41,23 +41,18 @@ Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` 
 #### To an existing Resource Group
 `az group deployment create --name "echoBotDeploy" --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="<botname>" appId="<appid>" appSecret="<appsecret>"`
 
-### 5. Update the pom.xml
-In pom.xml update the following nodes under azure-webapp-maven-plugin
-- `resourceGroup` using the `<groupname>` used above
-- `appName` using the `<botname>` used above
-
-### 6. Update app id and password
+### 5. Update app id and password
 In src/main/resources/application.properties update 
   - `MicrosoftAppPassword` with the appsecret value
   - `MicrosoftAppId` with the appid from the first step
 
-### 7. Deploy the code
+### 6. Deploy the code
 - Execute `mvn clean package` 
-- Execute `mvn azure-webapp:deploy`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<botname>"`
 
 If the deployment is successful, you will be able to test it via "Test in Web Chat" from the Azure Portal using the "Bot Channel Registration" for the bot.
 
-After the bot is deployed, you only need to execute #7 if you make changes to the bot.
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 
 ## Reference

--- a/samples/servlet-echo/pom.xml
+++ b/samples/servlet-echo/pom.xml
@@ -141,8 +141,8 @@
                   <version>1.7.0</version>
                   <configuration>
                       <schemaVersion>V2</schemaVersion>
-                      <resourceGroup>{groupname}</resourceGroup>
-                      <appName>{botname}</appName>
+                      <resourceGroup>${groupname}</resourceGroup>
+                      <appName>${botname}</appName>
                       <appSettings>
                           <property>
                               <name>JAVA_OPTS</name>


### PR DESCRIPTION
Fixes #828 

## Description
Modify pom.xml to use parameters for resourceGroup and appName so the pom.xml file doesn't need to be edited to include these, they can instead be passed on the command line of maven.

## Specific Changes
  - Updated pom.xml for samples to use parameters for resourceGroup and appName
  - Updated readme.md files to update deployment instructions to now pass the resource group and app name on the command line.

## Testing
All affected samples were deployed to Azure to verify that they were correct and would deploy with the new changes.