### PR TITLE
Updated samples to use port 3978

### DIFF
--- a/samples/02.echo-bot/README.md
+++ b/samples/02.echo-bot/README.md
@@ -25,7 +25,7 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ## Deploy the bot to Azure
 

--- a/samples/02.echo-bot/src/main/resources/application.properties
+++ b/samples/02.echo-bot/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/02.echo-bot/src/main/webapp/index.html
+++ b/samples/02.echo-bot/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/03.welcome-user/README.md
+++ b/samples/03.welcome-user/README.md
@@ -25,7 +25,7 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ## Deploy the bot to Azure
 

--- a/samples/03.welcome-user/src/main/resources/application.properties
+++ b/samples/03.welcome-user/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/03.welcome-user/src/main/webapp/index.html
+++ b/samples/03.welcome-user/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/08.suggested-actions/README.md
+++ b/samples/08.suggested-actions/README.md
@@ -25,7 +25,7 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ## Deploy the bot to Azure
 

--- a/samples/08.suggested-actions/bin/README.md
+++ b/samples/08.suggested-actions/bin/README.md
@@ -25,7 +25,7 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ## Deploy the bot to Azure
 

--- a/samples/08.suggested-actions/bin/src/main/webapp/index.html
+++ b/samples/08.suggested-actions/bin/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/08.suggested-actions/src/main/resources/application.properties
+++ b/samples/08.suggested-actions/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/08.suggested-actions/src/main/webapp/index.html
+++ b/samples/08.suggested-actions/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/16.proactive-messages/README.md
+++ b/samples/16.proactive-messages/README.md
@@ -34,7 +34,7 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ## Deploy the bot to Azure
 

--- a/samples/16.proactive-messages/bin/README.md
+++ b/samples/16.proactive-messages/bin/README.md
@@ -25,7 +25,7 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ## Deploy the bot to Azure
 

--- a/samples/16.proactive-messages/bin/src/main/webapp/index.html
+++ b/samples/16.proactive-messages/bin/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/ProactiveBot.java
+++ b/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/ProactiveBot.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
  */
 @Component
 public class ProactiveBot extends ActivityHandler {
-    @Value("${server.port:8080}")
+    @Value("${server.port:3978}")
     private int port;
 
     private static final String WELCOMEMESSAGE =

--- a/samples/16.proactive-messages/src/main/resources/application.properties
+++ b/samples/16.proactive-messages/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/16.proactive-messages/src/main/webapp/index.html
+++ b/samples/16.proactive-messages/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/45.state-management/README.md
+++ b/samples/45.state-management/README.md
@@ -28,7 +28,7 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ## Deploy the bot to Azure
 

--- a/samples/45.state-management/src/main/resources/application.properties
+++ b/samples/45.state-management/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/45.state-management/src/main/webapp/index.html
+++ b/samples/45.state-management/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/47.inspection/README.md
+++ b/samples/47.inspection/README.md
@@ -31,12 +31,12 @@ This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven p
 
     - Launch Bot Framework Emulator
     - File -> Open Bot
-    - Enter a Bot URL of `http://localhost:8080/api/messages`
+    - Enter a Bot URL of `http://localhost:3978/api/messages`
 
 ### Special Instructions for Running Inspection
 
 - In the emulator, select Debug -> Start Debugging.
-- Enter the endpoint url (http://localhost:8080)/api/messages, and select Connect.
+- Enter the endpoint url (http://localhost:3978)/api/messages, and select Connect.
 - The result is a trace activity which contains a statement that looks like /INSPECT attach < identifier >
 - Right click and copy that response.
 - In the original Live Chat session paste the value.

--- a/samples/47.inspection/src/main/resources/application.properties
+++ b/samples/47.inspection/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/47.inspection/src/main/webapp/index.html
+++ b/samples/47.inspection/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/50.teams-messaging-extensions-search/README.md
+++ b/samples/50.teams-messaging-extensions-search/README.md
@@ -23,10 +23,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/50.teams-messaging-extensions-search/src/main/resources/application.properties
+++ b/samples/50.teams-messaging-extensions-search/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/50.teams-messaging-extensions-search/src/main/webapp/index.html
+++ b/samples/50.teams-messaging-extensions-search/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/51.teams-messaging-extensions-action/README.md
+++ b/samples/51.teams-messaging-extensions-action/README.md
@@ -22,10 +22,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/51.teams-messaging-extensions-action/src/main/resources/application.properties
+++ b/samples/51.teams-messaging-extensions-action/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/51.teams-messaging-extensions-action/src/main/webapp/index.html
+++ b/samples/51.teams-messaging-extensions-action/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/52.teams-messaging-extensions-search-auth-config/README.md
+++ b/samples/52.teams-messaging-extensions-search-auth-config/README.md
@@ -22,10 +22,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/52.teams-messaging-extensions-search-auth-config/src/main/resources/application.properties
+++ b/samples/52.teams-messaging-extensions-search-auth-config/src/main/resources/application.properties
@@ -2,3 +2,4 @@ MicrosoftAppId=
 MicrosoftAppPassword=
 ConnectionName=
 SiteUrl=
+server.port=3978

--- a/samples/52.teams-messaging-extensions-search-auth-config/src/main/webapp/index.html
+++ b/samples/52.teams-messaging-extensions-search-auth-config/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/53.teams-messaging-extensions-action-preview/README.md
+++ b/samples/53.teams-messaging-extensions-action-preview/README.md
@@ -21,10 +21,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/53.teams-messaging-extensions-action-preview/src/main/resources/application.properties
+++ b/samples/53.teams-messaging-extensions-action-preview/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/53.teams-messaging-extensions-action-preview/src/main/webapp/index.html
+++ b/samples/53.teams-messaging-extensions-action-preview/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/54.teams-task-module/README.md
+++ b/samples/54.teams-task-module/README.md
@@ -20,10 +20,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/54.teams-task-module/src/main/resources/application.properties
+++ b/samples/54.teams-task-module/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
 BaseUrl=https://YourDeployedBotUrl.com
+server.port=3978

--- a/samples/55.teams-link-unfurling/README.md
+++ b/samples/55.teams-link-unfurling/README.md
@@ -21,10 +21,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/55.teams-link-unfurling/src/main/resources/application.properties
+++ b/samples/55.teams-link-unfurling/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/55.teams-link-unfurling/src/main/webapp/index.html
+++ b/samples/55.teams-link-unfurling/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/56.teams-file-upload/README.md
+++ b/samples/56.teams-file-upload/README.md
@@ -22,10 +22,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/56.teams-file-upload/src/main/resources/application.properties
+++ b/samples/56.teams-file-upload/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/56.teams-file-upload/src/main/webapp/index.html
+++ b/samples/56.teams-file-upload/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/57.teams-conversation-bot/README.md
+++ b/samples/57.teams-conversation-bot/README.md
@@ -22,10 +22,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/57.teams-conversation-bot/src/main/resources/application.properties
+++ b/samples/57.teams-conversation-bot/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
+server.port=3978

--- a/samples/57.teams-conversation-bot/src/main/webapp/index.html
+++ b/samples/57.teams-conversation-bot/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure

--- a/samples/58.teams-start-new-thread-in-channel/README.md
+++ b/samples/58.teams-start-new-thread-in-channel/README.md
@@ -21,10 +21,10 @@ the Teams service needs to call into the bot.
     git clone https://github.com/Microsoft/botbuilder-java.git
     ```
 
-1) Run ngrok - point to port 8080
+1) Run ngrok - point to port 3978
 
     ```bash
-    ngrok http -host-header=rewrite 8080
+    ngrok http -host-header=rewrite 3978
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure

--- a/samples/58.teams-start-new-thread-in-channel/src/main/resources/application.properties
+++ b/samples/58.teams-start-new-thread-in-channel/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 MicrosoftAppId =
 MicrosoftAppPassword =
+server.port=3978

--- a/samples/58.teams-start-new-thread-in-channel/src/main/webapp/index.html
+++ b/samples/58.teams-start-new-thread-in-channel/src/main/webapp/index.html
@@ -399,7 +399,7 @@
         <div class="column" class="main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
-                by connecting to http://localhost:8080/api/messages.</div>
+                by connecting to http://localhost:3978/api/messages.</div>
             <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
                     target="_blank">Download the Emulator</a></div>
             <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure


### PR DESCRIPTION
Fixes #825 
## Description
Update samples to use port 3978 to match other language samples.

## Specific Changes
  -Updated readme.md files to reflect new port 
  -Updated index.html pages with new port
  -Set port in application.properties files to set up local debugging to run on port 3978

## Testing
Deployed both locally and to Azure to ensure that port assignments were correct in each environment.