### PR TITLE
Refactored samples to use @Bean method for Bot instead of @Component.

### DIFF
--- a/samples/02.echo-bot/src/main/java/com/microsoft/bot/sample/echo/Application.java
+++ b/samples/02.echo-bot/src/main/java/com/microsoft/bot/sample/echo/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.echo;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +11,45 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- * <p>
- * This class also provides overrides for dependency injections. A class that extends the {@link
- * com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see EchoBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot() {
+        return new EchoBot();
     }
 
     /**

--- a/samples/02.echo-bot/src/main/java/com/microsoft/bot/sample/echo/EchoBot.java
+++ b/samples/02.echo-bot/src/main/java/com/microsoft/bot/sample/echo/EchoBot.java
@@ -9,7 +9,6 @@ import com.microsoft.bot.builder.MessageFactory;
 import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.schema.ChannelAccount;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -23,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
  * #onMembersAdded(List, TurnContext)} will send a greeting to new conversation participants.
  * </p>
  */
-@Component
 public class EchoBot extends ActivityHandler {
 
     @Override

--- a/samples/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/Application.java
+++ b/samples/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/Application.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.bot.sample.welcomeuser;
 
+import com.microsoft.bot.builder.Bot;
+import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +12,44 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see WelcomeUserBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(UserState userState) {
+        return new WelcomeUserBot(userState);
     }
 
     /**

--- a/samples/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/WelcomeUserBot.java
+++ b/samples/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/WelcomeUserBot.java
@@ -18,7 +18,6 @@ import com.microsoft.bot.schema.HeroCard;
 import com.microsoft.bot.schema.ResourceResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,7 +35,6 @@ import java.util.concurrent.CompletableFuture;
  *
  * @see WelcomeUserState
  */
-@Component
 public class WelcomeUserBot extends ActivityHandler {
     // Messages sent to the user.
     private static final String WELCOMEMESSAGE =

--- a/samples/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/Application.java
+++ b/samples/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/Application.java
@@ -3,6 +3,10 @@
 
 package com.microsoft.bot.sample.multiturnprompt;
 
+import com.microsoft.bot.builder.Bot;
+import com.microsoft.bot.builder.ConversationState;
+import com.microsoft.bot.builder.UserState;
+import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +14,63 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see DialogBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(
+        ConversationState conversationState,
+        UserState userState,
+        Dialog dialog
+    ) {
+        return new DialogBot(conversationState, userState, dialog);
+    }
+
+    /**
+     * Returns the starting Dialog for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Dialog class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Dialog implementation for this application.
+     */
+    @Bean
+    public Dialog getRootDialog(UserState userState) {
+        return new UserProfileDialog(userState);
     }
 
     /**

--- a/samples/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/DialogBot.java
+++ b/samples/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/DialogBot.java
@@ -10,7 +10,6 @@ import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.builder.UserState;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.stereotype.Component;
 
 /**
  * This IBot implementation can run any type of Dialog. The use of type parameterization is to
@@ -21,7 +20,6 @@ import org.springframework.stereotype.Component;
  * been used in a Dialog implementation, and the requirement is that all BotState objects are
  * saved at the end of a turn.
  */
-@Component
 public class DialogBot extends ActivityHandler {
     protected Dialog dialog;
     protected BotState conversationState;

--- a/samples/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/UserProfileDialog.java
+++ b/samples/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/UserProfileDialog.java
@@ -27,9 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
-@Component
 public class UserProfileDialog extends ComponentDialog {
     private StatePropertyAccessor<UserProfile> userProfileAccessor;
 

--- a/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/Application.java
+++ b/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/Application.java
@@ -3,6 +3,10 @@
 
 package com.microsoft.bot.sample.usingcards;
 
+import com.microsoft.bot.builder.Bot;
+import com.microsoft.bot.builder.ConversationState;
+import com.microsoft.bot.builder.UserState;
+import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +14,63 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see RichCardsBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(
+        ConversationState conversationState,
+        UserState userState,
+        Dialog rootDialog
+    ) {
+        return new RichCardsBot(conversationState, userState, rootDialog);
+    }
+
+    /**
+     * Returns the starting Dialog for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Dialog class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Dialog implementation for this application.
+     */
+    @Bean
+    public Dialog getRootDialog() {
+        return new MainDialog();
     }
 
     /**

--- a/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/MainDialog.java
+++ b/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/MainDialog.java
@@ -20,9 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.stereotype.Component;
 
-@Component
 public class MainDialog extends ComponentDialog {
     public MainDialog() {
         super("MainDialog");

--- a/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/RichCardsBot.java
+++ b/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/RichCardsBot.java
@@ -8,22 +8,21 @@ import com.microsoft.bot.builder.ConversationState;
 import com.microsoft.bot.builder.MessageFactory;
 import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.builder.UserState;
+import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ChannelAccount;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
 // RichCardsBot prompts a user to select a Rich Card and then returns the card
 // that matches the user's selection.
-@Component
-public class RichCardsBot extends DialogBot<MainDialog> {
+public class RichCardsBot extends DialogBot<Dialog> {
 
     public RichCardsBot(
         ConversationState withConversationState,
         UserState withUserState,
-        MainDialog withDialog
+        Dialog withDialog
     ) {
         super(withConversationState, withUserState, withDialog);
     }

--- a/samples/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/Application.java
+++ b/samples/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.suggestedactions;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +11,44 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see SuggestedActionsBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot() {
+        return new SuggestedActionsBot();
     }
 
     /**

--- a/samples/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/SuggestedActionsBot.java
+++ b/samples/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/SuggestedActionsBot.java
@@ -13,7 +13,6 @@ import com.microsoft.bot.schema.CardAction;
 import com.microsoft.bot.schema.ChannelAccount;
 import com.microsoft.bot.schema.SuggestedActions;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +29,6 @@ import java.util.concurrent.CompletableFuture;
  * conversation participants.
  * </p>
  */
-@Component
 public class SuggestedActionsBot extends ActivityHandler {
     public static final String WELCOMETEXT =
         "This bot will introduce you to suggestedActions." + " Please answer the question:";

--- a/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/Application.java
+++ b/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.proactive;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -13,38 +14,43 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see ProactiveBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
+//
+// See NotifyController in this project for an example on adding a controller.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
 
     /**
-     * Returns a custom Adapter that provides error handling.
+     * Returns the Bot for this application.
      *
-     * @param configuration The Configuration object to use.
-     * @return An error handling BotFrameworkHttpAdapter.
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
      */
-    @Override
-    public BotFrameworkHttpAdapter getBotFrameworkHttpAdaptor(Configuration configuration) {
-        return new AdapterWithErrorHandler(configuration);
+    @Bean
+    public Bot getBot(ConversationReferences conversationReferences) {
+        return new ProactiveBot(conversationReferences);
     }
 
     /**
@@ -56,5 +62,16 @@ public class Application extends BotDependencyConfiguration {
     @Bean
     public ConversationReferences getConversationReferences() {
         return new ConversationReferences();
+    }
+
+    /**
+     * Returns a custom Adapter that provides error handling.
+     *
+     * @param configuration The Configuration object to use.
+     * @return An error handling BotFrameworkHttpAdapter.
+     */
+    @Override
+    public BotFrameworkHttpAdapter getBotFrameworkHttpAdaptor(Configuration configuration) {
+        return new AdapterWithErrorHandler(configuration);
     }
 }

--- a/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/ProactiveBot.java
+++ b/samples/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/ProactiveBot.java
@@ -10,8 +10,8 @@ import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ChannelAccount;
 import com.microsoft.bot.schema.ConversationReference;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
  * conversation participants with instructions for sending a proactive message.
  * </p>
  */
-@Component
 public class ProactiveBot extends ActivityHandler {
     @Value("${server.port:3978}")
     private int port;
@@ -57,6 +56,10 @@ public class ProactiveBot extends ActivityHandler {
         TurnContext turnContext
     ) {
         return membersAdded.stream()
+            .filter(
+                member -> !StringUtils
+                    .equals(member.getId(), turnContext.getActivity().getRecipient().getId())
+            )
             .map(
                 channel -> turnContext
                     .sendActivity(MessageFactory.text(String.format(WELCOMEMESSAGE, port)))

--- a/samples/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/Application.java
+++ b/samples/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.multilingual;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.builder.ConversationState;
 import com.microsoft.bot.builder.Storage;
 import com.microsoft.bot.builder.UserState;
@@ -19,27 +20,41 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see MultiLingualBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(UserState userState) {
+        return new MultiLingualBot(userState);
     }
 
     /**

--- a/samples/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
+++ b/samples/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
@@ -36,7 +36,6 @@ import org.springframework.stereotype.Component;
  * More information can be found
  * here https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-info-overview.
  */
-@Component
 public class MultiLingualBot extends ActivityHandler {
     private static final String WELCOME_TEXT =
         new StringBuilder("This bot will introduce you to translation middleware. ")

--- a/samples/44.prompt-users-for-input/src/main/java/com/microsoft/bot/sample/promptusersforinput/Application.java
+++ b/samples/44.prompt-users-for-input/src/main/java/com/microsoft/bot/sample/promptusersforinput/Application.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.bot.sample.promptusersforinput;
 
+import com.microsoft.bot.builder.Bot;
+import com.microsoft.bot.builder.ConversationState;
+import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +13,47 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see DialogBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(
+        ConversationState conversationState,
+        UserState userState
+    ) {
+        return new CustomPromptBot(conversationState, userState);
     }
 
     /**

--- a/samples/44.prompt-users-for-input/src/main/java/com/microsoft/bot/sample/promptusersforinput/CustomPromptBot.java
+++ b/samples/44.prompt-users-for-input/src/main/java/com/microsoft/bot/sample/promptusersforinput/CustomPromptBot.java
@@ -32,7 +32,6 @@ import org.springframework.stereotype.Component;
  * endpoints within the same project. This can be achieved by defining distinct
  * Controller types each with dependency on distinct Bot types.
  */
-@Component
 public class CustomPromptBot extends ActivityHandler {
 
     private final BotState userState;

--- a/samples/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/Application.java
+++ b/samples/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/Application.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.bot.sample.statemanagement;
 
+import com.microsoft.bot.builder.Bot;
+import com.microsoft.bot.builder.ConversationState;
+import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +13,47 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see StateManagementBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(
+        ConversationState conversationState,
+        UserState userState
+    ) {
+        return new StateManagementBot(conversationState, userState);
     }
 
     /**

--- a/samples/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/StateManagementBot.java
+++ b/samples/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/StateManagementBot.java
@@ -34,7 +34,6 @@ import java.util.concurrent.CompletableFuture;
  * @see ConversationData
  * @see UserProfile
  */
-@Component
 public class StateManagementBot extends ActivityHandler {
     private ConversationState conversationState;
     private UserState userState;

--- a/samples/47.inspection/src/main/java/com/microsoft/bot/sample/inspection/Application.java
+++ b/samples/47.inspection/src/main/java/com/microsoft/bot/sample/inspection/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.inspection;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.builder.ConversationState;
 import com.microsoft.bot.builder.Storage;
 import com.microsoft.bot.builder.UserState;
@@ -18,34 +19,48 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * <p>
- * This class could provide overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- * </p>
- *
- * <p>
- * See README.md for details on using the InspectionMiddleware.
- * </p>
- *
- * @see BotDependencyConfiguration
- * @see EchoBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ *
+ * <p>
+ * See README.md for details on using the InspectionMiddleware.
+ * </p>
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(
+        ConversationState conversationState,
+        UserState userState
+    ) {
+        return new EchoBot(conversationState, userState);
     }
 
     /**

--- a/samples/47.inspection/src/main/java/com/microsoft/bot/sample/inspection/EchoBot.java
+++ b/samples/47.inspection/src/main/java/com/microsoft/bot/sample/inspection/EchoBot.java
@@ -26,7 +26,6 @@ import java.util.concurrent.CompletableFuture;
  * See README.md for details on using the InspectionMiddleware.
  * </p>
  */
-@Component
 public class EchoBot extends ActivityHandler {
     private ConversationState conversationState;
     private UserState userState;

--- a/samples/50.teams-messaging-extensions-search/pom.xml
+++ b/samples/50.teams-messaging-extensions-search/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20190722</version>
+        <version>20201115</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>

--- a/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/Application.java
+++ b/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamssearch;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,27 +11,44 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- * <p>
- * This class also provides overrides for dependency injections.  A class that extends the
- * {@link com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see TeamsMessagingExtensionsSearchBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot() {
+        return new TeamsMessagingExtensionsSearchBot();
     }
 
     /**

--- a/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/TeamsMessagingExtensionsSearchBot.java
+++ b/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/TeamsMessagingExtensionsSearchBot.java
@@ -15,7 +15,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.*;
@@ -28,7 +27,6 @@ import java.util.concurrent.CompletableFuture;
  * added.  This sample illustrates how to build a Search-based Messaging Extension.</p>
  */
 
-@Component
 public class TeamsMessagingExtensionsSearchBot extends TeamsActivityHandler {
 
     @Override

--- a/samples/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/Application.java
+++ b/samples/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamsaction;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,28 +11,45 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- * <p>
- * This class also provides overrides for dependency injections.  A class that extends the {@link
- * com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see TeamsMessagingExtensionsActionBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot() {
+        return new TeamsMessagingExtensionsActionBot();
     }
 
     /**

--- a/samples/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/TeamsMessagingExtensionsActionBot.java
+++ b/samples/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/TeamsMessagingExtensionsActionBot.java
@@ -8,7 +8,6 @@ import com.microsoft.bot.builder.teams.TeamsActivityHandler;
 import com.microsoft.bot.schema.CardImage;
 import com.microsoft.bot.schema.HeroCard;
 import com.microsoft.bot.schema.teams.*;
-import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -20,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
  * added.  There are two basic types of Messaging Extension in Teams: Search-based and Action-based.
  * This sample illustrates how to build an Action-based Messaging Extension.</p>
  */
-@Component
 public class TeamsMessagingExtensionsActionBot extends TeamsActivityHandler {
     @Override
     protected CompletableFuture<MessagingExtensionActionResponse> onTeamsMessagingExtensionSubmitAction(

--- a/samples/52.teams-messaging-extensions-search-auth-config/pom.xml
+++ b/samples/52.teams-messaging-extensions-search-auth-config/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>com.microsoft.graph</groupId>
         <artifactId>microsoft-graph</artifactId>
-        <version>1.7.1</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20190722</version>
+        <version>20201115</version>
         <scope>compile</scope>
       </dependency>
     </dependencies>

--- a/samples/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/Application.java
+++ b/samples/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/Application.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.bot.sample.teamssearchauth;
 
+import com.microsoft.bot.builder.Bot;
+import com.microsoft.bot.builder.ConversationState;
+import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,27 +13,47 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections.  A class that extends the
- * {@link com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see TeamsConversationBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(
+        Configuration configuration,
+        UserState userState
+    ) {
+        return new TeamsMessagingExtensionsSearchAuthConfigBot(configuration, userState);
     }
 
     /**

--- a/samples/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
+++ b/samples/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,7 +41,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * #onMembersAdded(List, TurnContext)} will send a greeting to new conversation participants.
  * </p>
  */
-@Component
 public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHandler {
 
     private String siteUrl;

--- a/samples/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/Application.java
+++ b/samples/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamsactionpreview;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,27 +11,44 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections.  A class that extends the
- * {@link com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see TeamsMessagingExtensionsActionPreviewBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot() {
+        return new TeamsMessagingExtensionsActionPreviewBot();
     }
 
     /**

--- a/samples/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/TeamsMessagingExtensionsActionPreviewBot.java
+++ b/samples/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/TeamsMessagingExtensionsActionPreviewBot.java
@@ -16,7 +16,6 @@ import com.microsoft.bot.schema.Attachment;
 import com.microsoft.bot.schema.teams.*;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,7 +33,6 @@ import java.util.stream.Collectors;
  * parameters entered by the user from a Task Module.
  * </p>
  */
-@Component
 public class TeamsMessagingExtensionsActionPreviewBot extends TeamsActivityHandler {
 
     @Override

--- a/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/Application.java
+++ b/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamstaskmodule;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,28 +11,45 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- * <p>
- * This class also provides overrides for dependency injections.  A class that extends the {@link
- * com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see TeamsTaskModuleBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(Configuration configuration) {
+        return new TeamsTaskModuleBot(configuration);
     }
 
     /**

--- a/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/TeamsTaskModuleBot.java
+++ b/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/TeamsTaskModuleBot.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
-import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -44,7 +43,6 @@ import java.util.concurrent.CompletableFuture;
  * user.  The {@link #onMembersAdded(List, TurnContext)} will send a greeting to new conversation
  * participants.</p>
  */
-@Component
 public class TeamsTaskModuleBot extends TeamsActivityHandler {
     private final String baseUrl;
     private final List<UISettings> actions = Arrays.asList(
@@ -79,7 +77,7 @@ public class TeamsTaskModuleBot extends TeamsActivityHandler {
     ) {
         // Called when the user selects an options from the displayed HeroCard or
         // AdaptiveCard.  The result is the action to perform.
-        return Async.tryCompletion(() -> {
+        return Async.wrapBlock(() -> {
             CardTaskFetchValue<String> value = Serialization
                 .safeGetAs(taskModuleRequest.getData(), CardTaskFetchValue.class);
 
@@ -126,7 +124,7 @@ public class TeamsTaskModuleBot extends TeamsActivityHandler {
         TaskModuleRequest taskModuleRequest
     ) {
         // Called when data is being returned from the selected option (see `onTeamsTaskModuleFetch').
-        return Async.tryCompletion(() ->
+        return Async.wrapBlock(() ->
             // Echo the users input back.  In a production bot, this is where you'd add behavior in
             // response to the input.
             MessageFactory.text(

--- a/samples/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/Application.java
+++ b/samples/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamsunfurl;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,28 +11,45 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- * <p>
- * This class also provides overrides for dependency injections.  A class that extends the {@link
- * com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see LinkUnfurlingBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot() {
+        return new LinkUnfurlingBot();
     }
 
     /**

--- a/samples/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/LinkUnfurlingBot.java
+++ b/samples/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/LinkUnfurlingBot.java
@@ -14,7 +14,6 @@ import com.microsoft.bot.schema.teams.MessagingExtensionQuery;
 import com.microsoft.bot.schema.teams.MessagingExtensionResponse;
 import com.microsoft.bot.schema.teams.MessagingExtensionResult;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -25,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
  * <p>This is where application specific logic for interacting with the users would be
  * added.</p>
  */
-@Component
 public class LinkUnfurlingBot extends TeamsActivityHandler {
 
     @Override

--- a/samples/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/Application.java
+++ b/samples/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamsfileupload;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,28 +11,45 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- * <p>
- * This class also provides overrides for dependency injections.  A class that extends the {@link
- * com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see TeamsFileUploadBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot() {
+        return new TeamsFileUploadBot();
     }
 
     /**

--- a/samples/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/TeamsFileUploadBot.java
+++ b/samples/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/TeamsFileUploadBot.java
@@ -16,7 +16,6 @@ import com.microsoft.bot.schema.teams.FileConsentCardResponse;
 import com.microsoft.bot.schema.teams.FileDownloadInfo;
 import com.microsoft.bot.schema.teams.FileInfoCard;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -41,7 +39,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * user.  The {@link #onMembersAdded(List, TurnContext)} will send a greeting to new conversation
  * participants.</p>
  */
-@Component
 public class TeamsFileUploadBot extends TeamsActivityHandler {
 
     @Override

--- a/samples/57.teams-conversation-bot/src/main/java/com/microsoft/bot/sample/teamsconversation/Application.java
+++ b/samples/57.teams-conversation-bot/src/main/java/com/microsoft/bot/sample/teamsconversation/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamsconversation;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,29 +11,44 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- *
- * This class also provides overrides for dependency injections. A class that
- * extends the {@link com.microsoft.bot.builder.Bot} interface should be
- * annotated with @Component.
- *
- * @see TeamsConversationBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
 // Use the default BotController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
-// RestController.
+// org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(Configuration configuration) {
+        return new TeamsConversationBot(configuration);
     }
 
     /**

--- a/samples/57.teams-conversation-bot/src/main/java/com/microsoft/bot/sample/teamsconversation/TeamsConversationBot.java
+++ b/samples/57.teams-conversation-bot/src/main/java/com/microsoft/bot/sample/teamsconversation/TeamsConversationBot.java
@@ -21,7 +21,6 @@ import com.microsoft.bot.schema.Mention;
 import com.microsoft.bot.schema.teams.TeamInfo;
 import com.microsoft.bot.schema.teams.TeamsChannelAccount;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -41,7 +40,6 @@ import java.util.concurrent.CompletableFuture;
  * will send a greeting to new conversation participants.
  * </p>
  */
-@Component
 public class TeamsConversationBot extends TeamsActivityHandler {
     private String appId;
     private String appPassword;

--- a/samples/58.teams-start-new-thread-in-channel/src/main/java/com/microsoft/bot/sample/teamsstartnewthread/Application.java
+++ b/samples/58.teams-start-new-thread-in-channel/src/main/java/com/microsoft/bot/sample/teamsstartnewthread/Application.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.bot.sample.teamsstartnewthread;
 
+import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.AdapterWithErrorHandler;
 import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
 import com.microsoft.bot.integration.Configuration;
@@ -10,28 +11,45 @@ import com.microsoft.bot.integration.spring.BotController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is the starting point of the Sprint Boot Bot application.
- * <p>
- * This class also provides overrides for dependency injections.  A class that extends the {@link
- * com.microsoft.bot.builder.Bot} interface should be annotated with @Component.
- *
- * @see TeamsStartNewThreadBot
- */
+//
+// This is the starting point of the Sprint Boot Bot application.
+//
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom controller
-// could be used by eliminating this import and creating a new RestController.  The default
-// controller is created by the Spring Boot container using dependency injection.  The
-// default route is /api/messages.
+// Use the default BotController to receive incoming Channel messages. A custom
+// controller could be used by eliminating this import and creating a new
+// org.springframework.web.bind.annotation.RestController.
+// The default controller is created by the Spring Boot container using
+// dependency injection. The default route is /api/messages.
 @Import({BotController.class})
 
+/**
+ * This class extends the BotDependencyConfiguration which provides the default
+ * implementations for a Bot application.  The Application class should
+ * override methods in order to provide custom implementations.
+ */
 public class Application extends BotDependencyConfiguration {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * Returns the Bot for this application.
+     *
+     * <p>
+     *     The @Component annotation could be used on the Bot class instead of this method
+     *     with the @Bean annotation.
+     * </p>
+     *
+     * @return The Bot implementation for this application.
+     */
+    @Bean
+    public Bot getBot(Configuration configuration) {
+        return new TeamsStartNewThreadBot(configuration);
     }
 
     /**

--- a/samples/58.teams-start-new-thread-in-channel/src/main/java/com/microsoft/bot/sample/teamsstartnewthread/TeamsStartNewThreadBot.java
+++ b/samples/58.teams-start-new-thread-in-channel/src/main/java/com/microsoft/bot/sample/teamsstartnewthread/TeamsStartNewThreadBot.java
@@ -14,7 +14,6 @@ import com.microsoft.bot.integration.Configuration;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ConversationParameters;
 import com.microsoft.bot.schema.ConversationReference;
-import org.springframework.stereotype.Component;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -25,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
  * added.  For this sample, the {@link #onMessageActivity(TurnContext)} creates a thread in a Teams channel.
  * </p>
  */
-@Component
 public class TeamsStartNewThreadBot extends TeamsActivityHandler {
 
     private String appId;


### PR DESCRIPTION
This is largely just a matter of it being easier to understand what the bots dependencies are.  An experienced dev might prefer to use @Component, which is also fine.