### PR TITLE
Corrects HTTP 500 in Sample 50.teams-messaging-extensions-search

### DIFF
--- a/samples/50.teams-messaging-extensions-search/pom.xml
+++ b/samples/50.teams-messaging-extensions-search/pom.xml
@@ -72,12 +72,7 @@
         <artifactId>log4j-api</artifactId>
         <version>2.11.0</version>
       </dependency>
-      <dependency>
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>20201115</version>
-      </dependency>
-      <dependency>
+     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
         <version>2.11.0</version>

--- a/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/TeamsMessagingExtensionsSearchBot.java
+++ b/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/TeamsMessagingExtensionsSearchBot.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.bot.sample.teamssearch;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.builder.teams.TeamsActivityHandler;
 import com.microsoft.bot.schema.*;
@@ -12,8 +15,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
@@ -44,11 +45,14 @@ public class TeamsMessagingExtensionsSearchBot extends TeamsActivityHandler {
             .thenApply(packages -> {
                 List<MessagingExtensionAttachment> attachments = new ArrayList<>();
                 for (String[] item : packages) {
+                    ObjectNode data = Serialization.createObjectNode();
+                    data.set("data", Serialization.objectToTree(item));
+
                     ThumbnailCard previewCard = new ThumbnailCard() {{
                         setTitle(item[0]);
                         setTap(new CardAction() {{
                             setType(ActionTypes.INVOKE);
-                            setValue(new JSONObject().put("data", item).toString());
+                            setValue(Serialization.toStringSilent(data));
                         }});
                     }};
 
@@ -129,23 +133,22 @@ public class TeamsMessagingExtensionsSearchBot extends TeamsActivityHandler {
                     ))
                 .build();
 
-            List<String[]> filteredItems = new ArrayList<String[]>();
+            List<String[]> filteredItems = new ArrayList<>();
             try {
                 Response response = client.newCall(request).execute();
-                JSONObject obj = new JSONObject(response.body().string());
-                JSONArray dataArray = (JSONArray) obj.get("data");
+                JsonNode obj = Serialization.jsonToTree(response.body().string());
+                ArrayNode dataArray = (ArrayNode) obj.get("data");
 
-                dataArray.forEach(i -> {
-                    JSONObject item = (JSONObject) i;
-                    filteredItems.add(new String[]{
-                        item.getString("id"),
-                        item.getString("version"),
-                        item.getString("description"),
-                        item.has("projectUrl") ? item.getString("projectUrl") : "",
-                        item.has("iconUrl") ? item.getString("iconUrl") : ""
+                for (int i = 0; i < dataArray.size(); i++) {
+                    JsonNode item = dataArray.get(i);
+                    filteredItems.add(new String[] {
+                        item.get("id").asText(),
+                        item.get("version").asText(),
+                        item.get("description").asText(),
+                        item.has("projectUrl") ? item.get("projectUrl").asText() : "",
+                        item.has("iconUrl") ? item.get("iconUrl").asText() : ""
                     });
-                });
-
+                }
             } catch (IOException e) {
                 LoggerFactory.getLogger(TeamsMessagingExtensionsSearchBot.class)
                     .error("findPackages", e);


### PR DESCRIPTION
Corrects HTTP 500 in Sample 50.teams-messaging-extensions-search.

Sample was using org.json.  For some reason, a method being used in the package was no longer found.  But since we already include Jackson as a dependency, just switched to using that instead of org.json.