### PR TITLE
TranscriptLoggerMiddleware set turnContext.Activity.From.Role

### DIFF
--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TranscriptMiddlewareTest.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TranscriptMiddlewareTest.java
@@ -282,7 +282,7 @@ public class TranscriptMiddlewareTest {
             // message. As demonstrated by the asserts after this TestFlow block
             // the role attribute is present on the activity as it is passed to
             // the transcript, but still missing inside the flow
-            Assert.assertNull(context.getActivity().getFrom().getRole());
+            Assert.assertNotNull(context.getActivity().getFrom().getRole());
             conversationId[0] = context.getActivity().getConversation().getId();
             context.sendActivity("echo:" + context.getActivity().getText()).join();
             return CompletableFuture.completedFuture(null);

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ActivityEventNames.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ActivityEventNames.java
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.bot.schema;
+
+/**
+ * Define values for common event names used by activities of type
+ * ActivityTypes.Event.
+ */
+public final class ActivityEventNames {
+    private ActivityEventNames() {
+
+    }
+
+    /**
+     * The event name for continuing a conversation.
+     */
+    public static final String CONTINUE_CONVERSATION = "ContinueConversation";
+
+    /**
+     * The event name for creating a conversation.
+     */
+    public static final String CREATE_CONVERSATION = "CreateConversation";
+}


### PR DESCRIPTION
Fixes #891 

Also brought to parity with:

```
            // log incoming activity at beginning of turn
            if (turnContext.Activity != null)
            {
                turnContext.Activity.From ??= new ChannelAccount();

                if (string.IsNullOrEmpty((string)turnContext.Activity.From.Properties["role"]) && string.IsNullOrEmpty(turnContext.Activity.From.Role))
                {
                    turnContext.Activity.From.Role = RoleTypes.User;
                }

                // We should not log ContinueConversation events used by skills to initialize the middleware.
                if (!(turnContext.Activity.Type == ActivityTypes.Event && turnContext.Activity.Name == ActivityEventNames.ContinueConversation))
                {
                    LogActivity(transcript, CloneActivity(turnContext.Activity));
                }
            }
```