### PR TITLE
[Samples & SDK] Replace Double Brace initialization with Standard Initialization

### DIFF
--- a/Generator/generator-botbuilder-java/generators/app/templates/core/src/main/java/DateResolverDialog.java
+++ b/Generator/generator-botbuilder-java/generators/app/templates/core/src/main/java/DateResolverDialog.java
@@ -75,12 +75,10 @@ public class DateResolverDialog extends CancelAndHelpDialog {
             return stepContext.prompt("DateTimePrompt", promptOptions);
         }
 
-        DateTimeResolution dateTimeResolution = new DateTimeResolution() {{
-            setTimex(timex);
-        }};
-        List<DateTimeResolution> dateTimeResolutions = new ArrayList<DateTimeResolution>() {{
-            add(dateTimeResolution);
-        }};
+        DateTimeResolution dateTimeResolution = new DateTimeResolution();
+        dateTimeResolution.setTimex(timex);
+        List<DateTimeResolution> dateTimeResolutions = new ArrayList<DateTimeResolution>();
+        dateTimeResolutions.add(dateTimeResolution);
         return stepContext.next(dateTimeResolutions);
     }
 

--- a/Generator/generator-botbuilder-java/generators/app/templates/core/src/main/java/DialogAndWelcomeBot.java
+++ b/Generator/generator-botbuilder-java/generators/app/templates/core/src/main/java/DialogAndWelcomeBot.java
@@ -85,10 +85,10 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            return new Attachment() {{
-                setContentType("application/vnd.microsoft.card.adaptive");
-                setContent(Serialization.jsonToTree(adaptiveCardJson));
-            }};
+            Attachment attachment = new Attachment();
+            attachment.setContentType("application/vnd.microsoft.card.adaptive");
+            attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
+            return attachment;
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/Generator/generator-botbuilder-java/generators/app/templates/core/src/main/java/FlightBookingRecognizer.java
+++ b/Generator/generator-botbuilder-java/generators/app/templates/core/src/main/java/FlightBookingRecognizer.java
@@ -42,12 +42,8 @@ public class FlightBookingRecognizer implements Recognizer {
             // Set the recognizer options depending on which endpoint version you want to use.
             // More details can be found in
             // https://docs.microsoft.com/en-gb/azure/cognitive-services/luis/luis-migration-api-v3
-            LuisRecognizerOptionsV3 recognizerOptions = new LuisRecognizerOptionsV3(
-                luisApplication) {
-                {
-                    setIncludeInstanceData(true);
-                }
-            };
+            LuisRecognizerOptionsV3 recognizerOptions = new LuisRecognizerOptionsV3(luisApplication);
+            recognizerOptions.setIncludeInstanceData(true);
 
             this.recognizer = new LuisRecognizer(recognizerOptions);
         }

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3.java
@@ -485,11 +485,8 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
         ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
 
         if (utterance == null || utterance.isEmpty()) {
-            recognizerResult = new RecognizerResult() {
-                {
-                    setText(utterance);
-                }
-            };
+            recognizerResult = new RecognizerResult();
+            recognizerResult.setText(utterance);
         } else {
             try {
                 Request request = buildRequest(buildRequestBody(utterance));
@@ -541,11 +538,9 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
             Map.Entry<String, JsonNode> intent = it.next();
             double score = intent.getValue().get("score").asDouble();
             String intentName = intent.getKey().replace(".", "_").replace(" ", "_");
-            intents.put(intentName, new IntentScore() {
-                {
-                    setScore(score);
-                }
-            });
+            IntentScore intentScore = new IntentScore();
+            intentScore.setScore(score);
+            intents.put(intentName, intentScore);
         }
 
         return intents;

--- a/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3Tests.java
+++ b/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3Tests.java
@@ -124,13 +124,9 @@ public class LuisRecognizerOptionsV3Tests {
             LuisRecognizerOptionsV3 v3 = buildTestRecognizer(endpoint, testSettings);
 
             // Run test
-            Activity activity = new Activity() {
-                {
-                    setText(testData.get("text").asText());
-                    setType(ActivityTypes.MESSAGE);
-                    setChannelId("EmptyContext");
-                }
-            };
+            Activity activity = new Activity(ActivityTypes.MESSAGE);
+            activity.setText(testData.get("text").asText());
+            activity.setChannelId("EmptyContext");
             doReturn(activity)
                 .when(turnContext)
                 .getActivity();
@@ -198,13 +194,9 @@ public class LuisRecognizerOptionsV3Tests {
             LuisRecognizerOptionsV3 v3 = buildTestRecognizer(endpoint, testSettings);
             v3.setExternalEntityRecognizer(recognizer);
 
-            Activity activity = new Activity() {
-                {
-                    setText(testData.get("text").asText());
-                    setType(ActivityTypes.MESSAGE);
-                    setChannelId("EmptyContext");
-                }
-            };
+            Activity activity = new Activity(ActivityTypes.MESSAGE);
+            activity.setText(testData.get("text").asText());
+            activity.setChannelId("EmptyContext");
 
             doReturn(CompletableFuture.completedFuture(new ResourceResponse()))
                 .when(turnContext)
@@ -212,9 +204,11 @@ public class LuisRecognizerOptionsV3Tests {
 
             when(dC.getContext()).thenReturn(turnContext);
 
-            doReturn(CompletableFuture.supplyAsync(() -> new RecognizerResult(){{
-                setEntities(testSettings.get("ExternalRecognizerResult"));
-            }}))
+            doReturn(CompletableFuture.supplyAsync(() -> {
+                RecognizerResult recognizerResult = new RecognizerResult();
+                recognizerResult.setEntities(testSettings.get("ExternalRecognizerResult"));
+                return recognizerResult;
+            }))
                 .when(recognizer)
                 .recognize(any(DialogContext.class), any(Activity.class));
 
@@ -244,13 +238,9 @@ public class LuisRecognizerOptionsV3Tests {
 
     public static TurnContext createContext(String message) {
 
-        Activity activity = new Activity() {
-            {
-                setText(message);
-                setType(ActivityTypes.MESSAGE);
-                setChannelId("EmptyContext");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText(message);
+        activity.setChannelId("EmptyContext");
 
         return new TurnContextImpl(new NotImplementedAdapter(), activity);
     }
@@ -323,18 +313,18 @@ public class LuisRecognizerOptionsV3Tests {
         ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
         ObjectReader readerDynamicList = mapper.readerFor(new TypeReference<List<DynamicList>>() {});
         ObjectReader readerExternalentities = mapper.readerFor(new TypeReference<List<ExternalEntity>>() {});
-        return new LuisRecognizerOptionsV3(
+        LuisRecognizerOptionsV3 recognizer = new LuisRecognizerOptionsV3(
             new LuisApplication(
                 this.applicationId,
                 this.subscriptionKey,
-                endpoint)) {{
-            setIncludeInstanceData(testSettings.get("IncludeInstanceData").asBoolean());
-            setIncludeAllIntents(testSettings.get("IncludeAllIntents").asBoolean());
-            setVersion(testSettings.get("Version") == null ? null : testSettings.get("Version").asText());
-            setDynamicLists(testSettings.get("DynamicLists") == null ? null : readerDynamicList.readValue(testSettings.get("DynamicLists")));
-            setExternalEntities(testSettings.get("ExternalEntities") == null ? null : readerExternalentities.readValue(testSettings.get("ExternalEntities")));
-            setDateTimeReference(testSettings.get("DateTimeReference") == null ? null : testSettings.get("DateTimeReference").asText());
-        }};
+                endpoint));
+        recognizer.setIncludeInstanceData(testSettings.get("IncludeInstanceData").asBoolean());
+        recognizer.setIncludeAllIntents(testSettings.get("IncludeAllIntents").asBoolean());
+        recognizer.setVersion(testSettings.get("Version") == null ? null : testSettings.get("Version").asText());
+        recognizer.setDynamicLists(testSettings.get("DynamicLists") == null ? null : readerDynamicList.readValue(testSettings.get("DynamicLists")));
+        recognizer.setExternalEntities(testSettings.get("ExternalEntities") == null ? null : readerExternalentities.readValue(testSettings.get("ExternalEntities")));
+        recognizer.setDateTimeReference(testSettings.get("DateTimeReference") == null ? null : testSettings.get("DateTimeReference").asText());
+        return recognizer;
     }
 
 }

--- a/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerTests.java
+++ b/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerTests.java
@@ -46,44 +46,44 @@ public class LuisRecognizerTests {
     @Mock
     LuisApplication luisApplication;
 
-    private RecognizerResult mockedResult = new RecognizerResult(){{
-        setIntents(new HashMap<String, IntentScore>(){{
-            put("Test",
-                new IntentScore(){{
-                setScore(0.2);
-            }});
-            put("Greeting",
-                new IntentScore(){{
-                setScore(0.4);
-            }});
-        }});
-        setEntities(JsonNodeFactory.instance.objectNode());
-        setProperties(
+    private RecognizerResult getMockedResult() {
+        RecognizerResult recognizerResult = new RecognizerResult();
+        HashMap<String, IntentScore> intents = new HashMap<String, IntentScore>();
+        IntentScore testScore = new IntentScore();
+        testScore.setScore(0.2);
+        IntentScore greetingScore = new IntentScore();
+        greetingScore.setScore(0.4);
+        intents.put("Test", testScore);
+        intents.put("Greeting", greetingScore);
+        recognizerResult.setIntents(intents);
+        recognizerResult.setEntities(JsonNodeFactory.instance.objectNode());
+        recognizerResult.setProperties(
             "sentiment",
             JsonNodeFactory.instance.objectNode()
                 .put(
                     "label",
                     "neutral"));
-    }};
+        return recognizerResult;
+    };
 
     @Test
     public void topIntentReturnsTopIntent() {
         String defaultIntent = LuisRecognizer
-            .topIntent(mockedResult);
+            .topIntent(getMockedResult());
         assertEquals(defaultIntent, "Greeting");
     }
 
     @Test
     public void topIntentReturnsDefaultIfMinScoreIsHigher() {
         String defaultIntent = LuisRecognizer
-            .topIntent(mockedResult, 0.5);
+            .topIntent(getMockedResult(), 0.5);
         assertEquals(defaultIntent, "None");
     }
 
     @Test
     public void topIntentReturnsDefaultIfProvided() {
         String defaultIntent = LuisRecognizer
-            .topIntent(mockedResult, "Test2", 0.5);
+            .topIntent(getMockedResult(), "Test2", 0.5);
         assertEquals(defaultIntent, "Test2");
     }
 
@@ -101,7 +101,7 @@ public class LuisRecognizerTests {
 
     @Test
     public void TopIntentReturnsTopIntentIfScoreEqualsMinScore() {
-        String defaultIntent = LuisRecognizer.topIntent(mockedResult, 0.4);
+        String defaultIntent = LuisRecognizer.topIntent(getMockedResult(), 0.4);
         assertEquals(defaultIntent, "Greeting");
     }
 
@@ -119,26 +119,23 @@ public class LuisRecognizerTests {
     public void recognizerResult() {
         setMockObjectsForTelemetry();
         LuisRecognizer recognizer = new LuisRecognizer(options);
-        RecognizerResult expected  = new RecognizerResult(){{
-            setText("Random Message");
-            setIntents(new HashMap<String, IntentScore>(){{
-                put("Test",
-                    new IntentScore(){{
-                        setScore(0.2);
-                    }});
-                put("Greeting",
-                    new IntentScore(){{
-                        setScore(0.4);
-                    }});
-            }});
-            setEntities(JsonNodeFactory.instance.objectNode());
-            setProperties(
-                "sentiment",
-                JsonNodeFactory.instance.objectNode()
-                    .put(
-                        "label",
-                        "neutral"));
-        }};
+        RecognizerResult expected = new RecognizerResult();
+        expected.setText("Random Message");
+        HashMap<String, IntentScore> intents = new HashMap<String, IntentScore>();
+        IntentScore testScore = new IntentScore();
+        testScore.setScore(0.2);
+        IntentScore greetingScore = new IntentScore();
+        greetingScore.setScore(0.4);
+        intents.put("Test", testScore);
+        intents.put("Greeting", greetingScore);
+        expected.setIntents(intents);
+        expected.setEntities(JsonNodeFactory.instance.objectNode());
+        expected.setProperties(
+            "sentiment",
+            JsonNodeFactory.instance.objectNode()
+                .put(
+                    "label",
+                    "neutral"));
         RecognizerResult actual = null;
         try {
             actual = recognizer.recognize(turnContext).get();
@@ -152,21 +149,21 @@ public class LuisRecognizerTests {
 
     @Test
     public void recognizerResult_nullTelemetryClient() {
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText("Random Message");
+        activity.setChannelId("EmptyContext");
+        ChannelAccount channelAccount = new ChannelAccount();
+        channelAccount.setId("Activity-from-ID");
+        activity.setFrom(channelAccount);
         when(turnContext.getActivity())
-            .thenReturn(new Activity() {{
-                setText("Random Message");
-                setType(ActivityTypes.MESSAGE);
-                setChannelId("EmptyContext");
-                setFrom(new ChannelAccount(){{
-                    setId("Activity-from-ID");
-                }});
-            }});
+            .thenReturn(activity);
 
         when(luisApplication.getApplicationId())
             .thenReturn("b31aeaf3-3511-495b-a07f-571fc873214b");
 
         when(options.getApplication())
             .thenReturn(luisApplication);
+        RecognizerResult mockedResult = getMockedResult();
         mockedResult.setText("Random Message");
         doReturn(CompletableFuture.supplyAsync(() -> mockedResult))
             .when(options)
@@ -174,26 +171,23 @@ public class LuisRecognizerTests {
                 any(TurnContext.class));
 
         LuisRecognizer recognizer = new LuisRecognizer(options);
-        RecognizerResult expected  = new RecognizerResult(){{
-            setText("Random Message");
-            setIntents(new HashMap<String, IntentScore>(){{
-                put("Test",
-                    new IntentScore(){{
-                        setScore(0.2);
-                    }});
-                put("Greeting",
-                    new IntentScore(){{
-                        setScore(0.4);
-                    }});
-            }});
-            setEntities(JsonNodeFactory.instance.objectNode());
-            setProperties(
+        RecognizerResult expected = new RecognizerResult();
+        expected.setText("Random Message");
+        HashMap<String, IntentScore> intents = new HashMap<String, IntentScore>();
+        IntentScore testScore = new IntentScore();
+        testScore.setScore(0.2);
+        IntentScore greetingScore = new IntentScore();
+        greetingScore.setScore(0.4);
+        intents.put("Test", testScore);
+        intents.put("Greeting", greetingScore);
+        expected.setIntents(intents);
+        expected.setEntities(JsonNodeFactory.instance.objectNode());
+        expected.setProperties(
                 "sentiment",
                 JsonNodeFactory.instance.objectNode()
                     .put(
                         "label",
                         "neutral"));
-        }};
         RecognizerResult actual = null;
         try {
             actual = recognizer.recognize(turnContext).get();
@@ -207,37 +201,32 @@ public class LuisRecognizerTests {
 
     @Test
     public void recognizerResultDialogContext() {
-        RecognizerResult expected  = new RecognizerResult(){{
-            setText("Random Message");
-            setIntents(new HashMap<String, IntentScore>(){{
-                put("Test",
-                    new IntentScore(){{
-                        setScore(0.2);
-                    }});
-                put("Greeting",
-                    new IntentScore(){{
-                        setScore(0.4);
-                    }});
-            }});
-            setEntities(JsonNodeFactory.instance.objectNode());
-            setProperties(
+        RecognizerResult expected = new RecognizerResult();
+        expected.setText("Random Message");
+        HashMap<String, IntentScore> intents = new HashMap<String, IntentScore>();
+        IntentScore testScore = new IntentScore();
+        testScore.setScore(0.2);
+        IntentScore greetingScore = new IntentScore();
+        greetingScore.setScore(0.4);
+        intents.put("Test", testScore);
+        intents.put("Greeting", greetingScore);
+        expected.setIntents(intents);
+        expected.setEntities(JsonNodeFactory.instance.objectNode());
+        expected.setProperties(
                 "sentiment",
                 JsonNodeFactory.instance.objectNode()
                     .put(
                         "label",
                         "neutral"));
-        }};
         RecognizerResult actual = null;
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText("Random Message");
+        activity.setChannelId("EmptyContext");
+        ChannelAccount channelAccount = new ChannelAccount();
+        channelAccount.setId("Activity-from-ID");
+        activity.setFrom(channelAccount);
         when(turnContext.getActivity())
-            .thenReturn(new Activity() {{
-                setText("Random Message");
-                setType(ActivityTypes.MESSAGE);
-                setChannelId("EmptyContext");
-                setFrom(new ChannelAccount(){{
-                    setId("Activity-from-ID");
-                }});
-            }});
-
+            .thenReturn(activity);
         when(luisApplication.getApplicationId())
             .thenReturn("b31aeaf3-3511-495b-a07f-571fc873214b");
 
@@ -245,6 +234,7 @@ public class LuisRecognizerTests {
 
         when(options.getApplication())
             .thenReturn(luisApplication);
+        RecognizerResult mockedResult = getMockedResult();
         mockedResult.setText("Random Message");
         when(dialogContext.getContext())
             .thenReturn(turnContext);
@@ -264,7 +254,6 @@ public class LuisRecognizerTests {
         }
     }
 
-
     @Test
     public void recognizerResultConverted() {
 
@@ -277,9 +266,8 @@ public class LuisRecognizerTests {
             e.printStackTrace();
         }
 
-        TestRecognizerResultConvert expected  = new TestRecognizerResultConvert(){{
-            recognizerResultText = "Random Message";
-        }};
+        TestRecognizerResultConvert expected = new TestRecognizerResultConvert();
+        expected.recognizerResultText = "Random Message";
 
         assertEquals(expected.recognizerResultText, actual.recognizerResultText);
     }
@@ -295,16 +283,15 @@ public class LuisRecognizerTests {
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
-        Map<String, String> expectedProperties = new HashMap<String, String> (){{
-            put("intentScore", "0.4");
-            put("intent2", "Test");
-            put("entities", "{}");
-            put("intentScore2", "0.2");
-            put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
-            put("intent", "Greeting");
-            put("fromId", "Activity-from-ID");
-            put("sentimentLabel", "neutral");
-        }};
+        Map<String, String> expectedProperties = new HashMap<String, String>();
+        expectedProperties.put("intentScore", "0.4");
+        expectedProperties.put("intent2", "Test");
+        expectedProperties.put("entities", "{}");
+        expectedProperties.put("intentScore2", "0.2");
+        expectedProperties.put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
+        expectedProperties.put("intent", "Greeting");
+        expectedProperties.put("fromId", "Activity-from-ID");
+        expectedProperties.put("sentimentLabel", "neutral");
 
         verify(telemetryClient, atLeastOnce()).trackEvent("LuisResult", expectedProperties, null);
     }
@@ -322,17 +309,16 @@ public class LuisRecognizerTests {
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
-        Map<String, String> expectedProperties = new HashMap<String, String> (){{
-            put("intentScore", "0.4");
-            put("intent2", "Test");
-            put("entities", "{}");
-            put("intentScore2", "0.2");
-            put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
-            put("intent", "Greeting");
-            put("fromId", "Activity-from-ID");
-            put("sentimentLabel", "neutral");
-            put("question", "Random Message");
-        }};
+        Map<String, String> expectedProperties = new HashMap<String, String>();
+        expectedProperties.put("intentScore", "0.4");
+        expectedProperties.put("intent2", "Test");
+        expectedProperties.put("entities", "{}");
+        expectedProperties.put("intentScore2", "0.2");
+        expectedProperties.put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
+        expectedProperties.put("intent", "Greeting");
+        expectedProperties.put("fromId", "Activity-from-ID");
+        expectedProperties.put("sentimentLabel", "neutral");
+        expectedProperties.put("question", "Random Message");
 
         verify(telemetryClient, atLeastOnce()).trackEvent("LuisResult", expectedProperties, null);
     }
@@ -343,32 +329,29 @@ public class LuisRecognizerTests {
         when(options.isLogPersonalInformation()).thenReturn(true);
 
         LuisRecognizer recognizer = new LuisRecognizer(options);
-        Map<String, String> additionalProperties = new HashMap<String, String>(){{
-            put("test", "testvalue");
-            put("foo", "foovalue");
-        }};
-        Map<String, Double> telemetryMetrics = new HashMap<String, Double>(){{
-            put("test", 3.1416);
-            put("foo", 2.11);
-        }};
+        Map<String, String> additionalProperties = new HashMap<String, String>();
+        additionalProperties.put("test", "testvalue");
+        additionalProperties.put("foo", "foovalue");
+        Map<String, Double> telemetryMetrics = new HashMap<String, Double>();
+        telemetryMetrics.put("test", 3.1416);
+        telemetryMetrics.put("foo", 2.11);
         try {
             recognizer.recognize(turnContext, additionalProperties, telemetryMetrics).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
-        Map<String, String> expectedProperties = new HashMap<String, String> (){{
-            put("intentScore", "0.4");
-            put("intent2", "Test");
-            put("entities", "{}");
-            put("intentScore2", "0.2");
-            put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
-            put("intent", "Greeting");
-            put("fromId", "Activity-from-ID");
-            put("sentimentLabel", "neutral");
-            put("question", "Random Message");
-            put("test", "testvalue");
-            put("foo", "foovalue");
-        }};
+        Map<String, String> expectedProperties = new HashMap<String, String>();
+        expectedProperties.put("intentScore", "0.4");
+        expectedProperties.put("intent2", "Test");
+        expectedProperties.put("entities", "{}");
+        expectedProperties.put("intentScore2", "0.2");
+        expectedProperties.put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
+        expectedProperties.put("intent", "Greeting");
+        expectedProperties.put("fromId", "Activity-from-ID");
+        expectedProperties.put("sentimentLabel", "neutral");
+        expectedProperties.put("question", "Random Message");
+        expectedProperties.put("test", "testvalue");
+        expectedProperties.put("foo", "foovalue");
 
         verify(telemetryClient, atLeastOnce()).trackEvent("LuisResult", expectedProperties, telemetryMetrics);
     }
@@ -379,45 +362,42 @@ public class LuisRecognizerTests {
         when(options.isLogPersonalInformation()).thenReturn(true);
 
         LuisRecognizer recognizer = new LuisRecognizer(options);
-        Map<String, String> additionalProperties = new HashMap<String, String>(){{
-            put("intentScore", "1.15");
-            put("foo", "foovalue");
-        }};
-        Map<String, Double> telemetryMetrics = new HashMap<String, Double>(){{
-            put("test", 3.1416);
-            put("foo", 2.11);
-        }};
+        Map<String, String> additionalProperties = new HashMap<String, String>();
+        additionalProperties.put("intentScore", "1.15");
+        additionalProperties.put("foo", "foovalue");
+        Map<String, Double> telemetryMetrics = new HashMap<String, Double>();
+        telemetryMetrics.put("test", 3.1416);
+        telemetryMetrics.put("foo", 2.11);
         try {
             recognizer.recognize(turnContext, additionalProperties, telemetryMetrics).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
-        Map<String, String> expectedProperties = new HashMap<String, String> (){{
-            put("intentScore", "1.15");
-            put("intent2", "Test");
-            put("entities", "{}");
-            put("intentScore2", "0.2");
-            put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
-            put("intent", "Greeting");
-            put("fromId", "Activity-from-ID");
-            put("sentimentLabel", "neutral");
-            put("question", "Random Message");
-            put("foo", "foovalue");
-        }};
+        Map<String, String> expectedProperties = new HashMap<String, String>();
+        expectedProperties.put("intentScore", "1.15");
+        expectedProperties.put("intent2", "Test");
+        expectedProperties.put("entities", "{}");
+        expectedProperties.put("intentScore2", "0.2");
+        expectedProperties.put("applicationId", "b31aeaf3-3511-495b-a07f-571fc873214b");
+        expectedProperties.put("intent", "Greeting");
+        expectedProperties.put("fromId", "Activity-from-ID");
+        expectedProperties.put("sentimentLabel", "neutral");
+        expectedProperties.put("question", "Random Message");
+        expectedProperties.put("foo", "foovalue");
 
         verify(telemetryClient, atLeastOnce()).trackEvent("LuisResult", expectedProperties, telemetryMetrics);
     }
 
     private void setMockObjectsForTelemetry() {
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText("Random Message");
+        activity.setType(ActivityTypes.MESSAGE);
+        activity.setChannelId("EmptyContext");
+        ChannelAccount channelAccount = new ChannelAccount();
+        channelAccount.setId("Activity-from-ID");
+        activity.setFrom(channelAccount);
         when(turnContext.getActivity())
-            .thenReturn(new Activity() {{
-                setText("Random Message");
-                setType(ActivityTypes.MESSAGE);
-                setChannelId("EmptyContext");
-                setFrom(new ChannelAccount(){{
-                    setId("Activity-from-ID");
-                }});
-            }});
+            .thenReturn(activity);
 
         when(luisApplication.getApplicationId())
             .thenReturn("b31aeaf3-3511-495b-a07f-571fc873214b");
@@ -426,6 +406,7 @@ public class LuisRecognizerTests {
 
         when(options.getApplication())
             .thenReturn(luisApplication);
+        RecognizerResult mockedResult = getMockedResult();
         mockedResult.setText("Random Message");
         doReturn(CompletableFuture.supplyAsync(() -> mockedResult))
             .when(options)

--- a/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/utils/GenerateAnswerUtils.java
+++ b/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/utils/GenerateAnswerUtils.java
@@ -250,19 +250,18 @@ public class GenerateAnswerUtils {
         JacksonAdapter jacksonAdapter = new JacksonAdapter();
         String jsonRequest = null;
 
-        jsonRequest = jacksonAdapter.serialize(new JSONObject() {
-            {
-                put("question", messageActivity.getText());
-                put("top", withOptions.getTop());
-                put("strictFilters", withOptions.getStrictFilters());
-                put("scoreThreshold", withOptions.getScoreThreshold());
-                put("context", withOptions.getContext());
-                put("qnaId", withOptions.getQnAId());
-                put("isTest", withOptions.getIsTest());
-                put("rankerType", withOptions.getRankerType());
-                put("StrictFiltersCompoundOperationType", withOptions.getStrictFiltersJoinOperator());
-            }
-        });
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("question", messageActivity.getText());
+        jsonObject.put("top", withOptions.getTop());
+        jsonObject.put("strictFilters", withOptions.getStrictFilters());
+        jsonObject.put("scoreThreshold", withOptions.getScoreThreshold());
+        jsonObject.put("context", withOptions.getContext());
+        jsonObject.put("qnaId", withOptions.getQnAId());
+        jsonObject.put("isTest", withOptions.getIsTest());
+        jsonObject.put("rankerType", withOptions.getRankerType());
+        jsonObject.put("StrictFiltersCompoundOperationType", withOptions.getStrictFiltersJoinOperator());
+
+        jsonRequest = jacksonAdapter.serialize(jsonObject);
 
         HttpRequestUtils httpRequestHelper = new HttpRequestUtils();
         return httpRequestHelper.executeHttpRequest(requestUrl, jsonRequest, this.endpoint).thenCompose(response -> {

--- a/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/utils/QnACardBuilder.java
+++ b/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/utils/QnACardBuilder.java
@@ -49,29 +49,23 @@ public final class QnACardBuilder {
 
         // Add all suggestions
         for (String suggestion : suggestionsList) {
-            buttonList.add(new CardAction() {
-                {
-                    setValue(suggestion);
-                    setType(ActionTypes.IM_BACK);
-                    setTitle(suggestion);
-                }
-            });
+            CardAction cardAction = new CardAction();
+            cardAction.setValue(suggestion);
+            cardAction.setType(ActionTypes.IM_BACK);
+            cardAction.setTitle(suggestion);
+
+            buttonList.add(cardAction);
         }
 
         // Add No match text
-        buttonList.add(new CardAction() {
-            {
-                setValue(cardNoMatchText);
-                setType(ActionTypes.IM_BACK);
-                setTitle(cardNoMatchText);
-            }
-        });
+        CardAction cardAction = new CardAction();
+        cardAction.setValue(cardNoMatchText);
+        cardAction.setType(ActionTypes.IM_BACK);
+        cardAction.setTitle(cardNoMatchText);
+        buttonList.add(cardAction);
 
-        HeroCard plCard = new HeroCard() {
-            {
-                setButtons(buttonList);
-            }
-        };
+        HeroCard plCard = new HeroCard();
+        plCard.setButtons(buttonList);
 
         // Create the attachment.
         Attachment attachment = plCard.toAttachment();
@@ -103,20 +97,15 @@ public final class QnACardBuilder {
 
         // Add all prompt
         for (QnAMakerPrompt prompt : result.getContext().getPrompts()) {
-            buttonList.add(new CardAction() {
-                {
-                    setValue(prompt.getDisplayText());
-                    setType(ActionTypes.IM_BACK);
-                    setTitle(prompt.getDisplayText());
-                }
-            });
+            CardAction card = new CardAction();
+            card.setValue(prompt.getDisplayText());
+            card.setType(ActionTypes.IM_BACK);
+            card.setTitle(prompt.getDisplayText());
+            buttonList.add(card);
         }
 
-        HeroCard plCard = new HeroCard() {
-            {
-                setButtons(buttonList);
-            }
-        };
+        HeroCard plCard = new HeroCard();
+        plCard.setButtons(buttonList);
 
         // Create the attachment.
         Attachment attachment = plCard.toAttachment();

--- a/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerRecognizerTests.java
+++ b/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerRecognizerTests.java
@@ -36,13 +36,11 @@ public class QnAMakerRecognizerTests {
 
     @Test
     public void logPiiIsFalseByDefault() {
-        QnAMakerRecognizer recognizer = new QnAMakerRecognizer() {
-            {
-                setHostName(hostname);
-                setEndpointKey(endpointKey);
-                setKnowledgeBaseId(knowledgeBaseId);
-            }
-        };
+        QnAMakerRecognizer recognizer = new QnAMakerRecognizer();
+        recognizer.setHostName(hostname);
+        recognizer.setEndpointKey(endpointKey);
+        recognizer.setKnowledgeBaseId(knowledgeBaseId);
+
         Boolean logPersonalInfo = recognizer.getLogPersonalInformation();
         // Should be false by default, when not specified by user.
         Assert.assertFalse(logPersonalInfo);
@@ -53,13 +51,11 @@ public class QnAMakerRecognizerTests {
         Activity activity = Activity.createMessageActivity();
         TurnContext context = new TurnContextImpl(new TestAdapter(), activity);
         DialogContext dc = new DialogContext(new DialogSet(), context, new DialogState());
-        QnAMakerRecognizer recognizer = new QnAMakerRecognizer() {
-            {
-                setHostName(hostname);
-                setKnowledgeBaseId(knowledgeBaseId);
-                setEndpointKey(endpointKey);
-            }
-        };
+        QnAMakerRecognizer recognizer = new QnAMakerRecognizer();
+        recognizer.setHostName(hostname);
+        recognizer.setKnowledgeBaseId(knowledgeBaseId);
+        recognizer.setEndpointKey(endpointKey);
+
         RecognizerResult result = recognizer.recognize(dc, activity).join();
         Assert.assertEquals(result.getEntities(), null);
         Assert.assertEquals(result.getProperties().get("answers"), null);
@@ -81,13 +77,11 @@ public class QnAMakerRecognizerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer,response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerRecognizer recognizer = new QnAMakerRecognizer() {
-                {
-                    setHostName(finalEndpoint);
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                }
-            };
+            QnAMakerRecognizer recognizer = new QnAMakerRecognizer();
+            recognizer.setHostName(finalEndpoint);
+            recognizer.setKnowledgeBaseId(knowledgeBaseId);
+            recognizer.setEndpointKey(endpointKey);
+
             Activity activity = Activity.createMessageActivity();
             activity.setText("test");
             TurnContext context = new TurnContextImpl(new TestAdapter(), activity);
@@ -123,13 +117,11 @@ public class QnAMakerRecognizerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer,response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerRecognizer recognizer = new QnAMakerRecognizer() {
-                {
-                    setHostName(finalEndpoint);
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                }
-            };
+            QnAMakerRecognizer recognizer = new QnAMakerRecognizer();
+            recognizer.setHostName(finalEndpoint);
+            recognizer.setKnowledgeBaseId(knowledgeBaseId);
+            recognizer.setEndpointKey(endpointKey);
+
             Activity activity = Activity.createMessageActivity();
             activity.setText("test");
             TurnContext context = new TurnContextImpl(new TestAdapter(), activity);
@@ -163,13 +155,11 @@ public class QnAMakerRecognizerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer,response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerRecognizer recognizer = new QnAMakerRecognizer() {
-                {
-                    setHostName(finalEndpoint);
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                }
-            };
+            QnAMakerRecognizer recognizer = new QnAMakerRecognizer();
+            recognizer.setHostName(finalEndpoint);
+            recognizer.setKnowledgeBaseId(knowledgeBaseId);
+            recognizer.setEndpointKey(endpointKey);
+
             Activity activity = Activity.createMessageActivity();
             activity.setText("test");
             TurnContext context = new TurnContextImpl(new TestAdapter(), activity);
@@ -203,13 +193,11 @@ public class QnAMakerRecognizerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer,response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerRecognizer recognizer = new QnAMakerRecognizer() {
-                {
-                    setHostName(finalEndpoint);
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                }
-            };
+            QnAMakerRecognizer recognizer = new QnAMakerRecognizer();
+            recognizer.setHostName(finalEndpoint);
+            recognizer.setKnowledgeBaseId(knowledgeBaseId);
+            recognizer.setEndpointKey(endpointKey);
+
             Activity activity = Activity.createMessageActivity();
             activity.setText("test");
             TurnContext context = new TurnContextImpl(new TestAdapter(), activity);

--- a/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTests.java
+++ b/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTests.java
@@ -127,12 +127,8 @@ public class QnAMakerTests {
                 }
                 delay(500);
                 conversationId[0] = turnContext.getActivity().getConversation().getId();
-                Activity typingActivity = new Activity() {
-                    {
-                        setType(ActivityTypes.TYPING);
-                        setRelatesTo(turnContext.getActivity().getRelatesTo());
-                    }
-                };
+                Activity typingActivity = new Activity(ActivityTypes.TYPING);
+                typingActivity.setRelatesTo(turnContext.getActivity().getRelatesTo());
                 turnContext.sendActivity(typingActivity).join();
                 delay(500);
                 turnContext.sendActivity(String.format("echo:%s", turnContext.getActivity().getText())).join();
@@ -182,15 +178,12 @@ public class QnAMakerTests {
             // No text
             TestAdapter adapter = new TestAdapter(
                 TestAdapter.createConversationReference("QnaMaker_TraceActivity_EmptyText", "User1", "Bot"));
-            Activity activity = new Activity() {
-                {
-                    setType(ActivityTypes.MESSAGE);
-                    setText(new String());
-                    setConversation(new ConversationAccount());
-                    setRecipient(new ChannelAccount());
-                    setFrom(new ChannelAccount());
-                }
-            };
+            Activity activity = new Activity(ActivityTypes.MESSAGE);
+            activity.setText(new String());
+            activity.setConversation(new ConversationAccount());
+            activity.setRecipient(new ChannelAccount());
+            activity.setFrom(new ChannelAccount());
+
             TurnContext context = new TurnContextImpl(adapter, activity);
             Assert.assertThrows(CompletionException.class, () -> qna.getAnswers(context, null).join());
         } catch (Exception e) {
@@ -214,15 +207,12 @@ public class QnAMakerTests {
             // No text
             TestAdapter adapter = new TestAdapter(
                 TestAdapter.createConversationReference("QnaMaker_TraceActivity_NullText", "User1", "Bot"));
-            Activity activity = new Activity() {
-                {
-                    setType(ActivityTypes.MESSAGE);
-                    setText(null);
-                    setConversation(new ConversationAccount());
-                    setRecipient(new ChannelAccount());
-                    setFrom(new ChannelAccount());
-                }
-            };
+            Activity activity = new Activity(ActivityTypes.MESSAGE);
+            activity.setText(null);
+            activity.setConversation(new ConversationAccount());
+            activity.setRecipient(new ChannelAccount());
+            activity.setFrom(new ChannelAccount());
+
             TurnContext context = new TurnContextImpl(adapter, activity);
             Assert.assertThrows(CompletionException.class, () -> qna.getAnswers(context, null).join());
         } catch (Exception e) {
@@ -265,15 +255,11 @@ public class QnAMakerTests {
             // No text
             TestAdapter adapter = new TestAdapter(
                 TestAdapter.createConversationReference("QnaMaker_TraceActivity_BadMessage", "User1", "Bot"));
-            Activity activity = new Activity() {
-                {
-                    setType(ActivityTypes.TRACE);
-                    setText("My Text");
-                    setConversation(new ConversationAccount());
-                    setRecipient(new ChannelAccount());
-                    setFrom(new ChannelAccount());
-                }
-            };
+            Activity activity = new Activity(ActivityTypes.TRACE);
+            activity.setText("My Text");
+            activity.setConversation(new ConversationAccount());
+            activity.setRecipient(new ChannelAccount());
+            activity.setFrom(new ChannelAccount());
 
             TurnContext context = new TurnContextImpl(adapter, activity);
             Assert.assertThrows(CompletionException.class, () -> qna.getAnswers(context, null).join());
@@ -336,11 +322,9 @@ public class QnAMakerTests {
         MockWebServer mockWebServer = new MockWebServer();
         try {
             QnAMaker qna = this.qnaReturnsAnswer(mockWebServer);
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
+
             QueryResults results = qna.getAnswersRaw(getContext("how do I clean the stove?"), options, null, null).join();
             Assert.assertNotNull(results.getAnswers());
             Assert.assertTrue(results.getActiveLearningEnabled());
@@ -371,18 +355,13 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions() {
-                {
-                    setTop(5);
-                }
-            };
+            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint();
+            qnaMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnaMakerEndpoint.setEndpointKey(endpointKey);
+            qnaMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions();
+            qnaMakerOptions.setTop(5);
             QnAMaker qna = new QnAMaker(qnaMakerEndpoint, qnaMakerOptions);
             QueryResult[] results = qna.getAnswers(getContext("Q11"), null).join();
             Assert.assertNotNull(results);
@@ -429,31 +408,23 @@ public class QnAMakerTests {
                     response,
                     url).port());
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
+            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint();
+            qnaMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnaMakerEndpoint.setEndpointKey(endpointKey);
+            qnaMakerEndpoint.setHost(finalEndpoint);
+
             QnAMaker qna = new QnAMaker(qnaMakerEndpoint, null);
             FeedbackRecords feedbackRecords = new FeedbackRecords();
 
-            FeedbackRecord feedback1 = new FeedbackRecord() {
-                {
-                    setQnaId(1);
-                    setUserId("test");
-                    setUserQuestion("How are you?");
-                }
-            };
+            FeedbackRecord feedback1 = new FeedbackRecord();
+            feedback1.setQnaId(1);
+            feedback1.setUserId("test");
+            feedback1.setUserQuestion("How are you?");
 
-            FeedbackRecord feedback2 = new FeedbackRecord() {
-                {
-                    setQnaId(2);
-                    setUserId("test");
-                    setUserQuestion("What up??");
-                }
-            };
+            FeedbackRecord feedback2 = new FeedbackRecord();
+            feedback2.setQnaId(2);
+            feedback2.setUserId("test");
+            feedback2.setUserQuestion("What up??");
 
             feedbackRecords.setRecords(new FeedbackRecord[] { feedback1, feedback2 });
             qna.callTrain(feedbackRecords);
@@ -502,24 +473,18 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions() {
-                {
-                    setStrictFilters(new Metadata[] { new Metadata() {
-                        {
-                            setName("topic");
-                            setValue("value");
-                        }
-                    } });
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint();
+            qnaMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnaMakerEndpoint.setEndpointKey(endpointKey);
+            qnaMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions();
+            Metadata metadata = new Metadata();
+            metadata.setName("topic");
+            metadata.setValue("value");
+            Metadata[] filters = new Metadata[] { metadata };
+            qnaMakerOptions.setStrictFilters(filters);
+            qnaMakerOptions.setTop(1);
             QnAMaker qna = new QnAMaker(qnaMakerEndpoint, qnaMakerOptions);
             ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
@@ -566,25 +531,20 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions() {
-                {
-                    setScoreThreshold(0.0f);
-                }
-            };
+            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint();
+            qnaMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnaMakerEndpoint.setEndpointKey(endpointKey);
+            qnaMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions();
+            qnaMakerOptions.setScoreThreshold(0.0f);
+
             QnAMaker qnaWithZeroValueThreshold = new QnAMaker(qnaMakerEndpoint, qnaMakerOptions);
 
-            QueryResult[] results = qnaWithZeroValueThreshold.getAnswers(getContext("how do I clean the stove?"), new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            }).join();
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
+
+            QueryResult[] results = qnaWithZeroValueThreshold.getAnswers(getContext("how do I clean the stove?"), options).join();
             Assert.assertNotNull(results);
             Assert.assertTrue(results.length == 1);
         } catch (Exception e) {
@@ -611,19 +571,15 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                    setScoreThreshold(0.99F);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions();
+            qnaMakerOptions.setTop(1);
+            qnaMakerOptions.setScoreThreshold(0.99F);
+
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, qnaMakerOptions);
 
             QueryResult[] results = qna.getAnswers(getContext("how do I clean the stove?"), null).join();
@@ -642,37 +598,29 @@ public class QnAMakerTests {
 
     @Test
     public void qnaMakerTestScoreThresholdTooLargeOutOfRange() {
-        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-            {
-                setKnowledgeBaseId(knowledgeBaseId);
-                setEndpointKey(endpointKey);
-                setHost(hostname);
-            }
-        };
-        QnAMakerOptions tooLargeThreshold = new QnAMakerOptions() {
-            {
-                setTop(1);
-                setScoreThreshold(1.1f);
-            }
-        };
+        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+        qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+        qnAMakerEndpoint.setEndpointKey(endpointKey);
+        qnAMakerEndpoint.setHost(hostname);
+
+        QnAMakerOptions tooLargeThreshold = new QnAMakerOptions();
+        tooLargeThreshold.setTop(1);
+        tooLargeThreshold.setScoreThreshold(1.1f);
+
         Assert.assertThrows(IllegalArgumentException.class, () -> new QnAMaker(qnAMakerEndpoint, tooLargeThreshold));
     }
 
     @Test
     public void qnaMakerTestScoreThresholdTooSmallOutOfRange() {
-        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-            {
-                setKnowledgeBaseId(knowledgeBaseId);
-                setEndpointKey(endpointKey);
-                setHost(hostname);
-            }
-        };
-        QnAMakerOptions tooSmallThreshold = new QnAMakerOptions() {
-            {
-                setTop(1);
-                setScoreThreshold(-9000.0f);
-            }
-        };
+        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+        qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+        qnAMakerEndpoint.setEndpointKey(endpointKey);
+        qnAMakerEndpoint.setHost(hostname);
+
+        QnAMakerOptions tooSmallThreshold = new QnAMakerOptions();
+        tooSmallThreshold.setTop(1);
+        tooSmallThreshold.setScoreThreshold(-9000.0f);
+
         Assert.assertThrows(IllegalArgumentException.class, () -> new QnAMaker(qnAMakerEndpoint, tooSmallThreshold));
     }
 
@@ -689,25 +637,18 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnARequestContext context = new QnARequestContext() {
-                {
-                    setPreviousQnAId(5);
-                    setPreviousUserQuery("how do I clean the stove?");
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                    setContext(context);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnARequestContext context = new QnARequestContext();
+            context.setPreviousQnAId(5);
+            context.setPreviousUserQuery("how do I clean the stove?");
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
+            options.setContext(context);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, options);
 
@@ -740,18 +681,13 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(3);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(3);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, options);
 
@@ -783,19 +719,14 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                    setQnAId(55);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
+            options.setQnAId(55);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, options);
             QueryResult[] results = qna.getAnswers(getContext("Where can I buy?"), options).join();
@@ -816,55 +747,45 @@ public class QnAMakerTests {
 
     @Test
     public void qnaMakerTestTopOutOfRange() {
-        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-            {
-                setKnowledgeBaseId(knowledgeBaseId);
-                setEndpointKey(endpointKey);
-                setHost(hostname);
-            }
-        };
-        QnAMakerOptions options = new QnAMakerOptions() {
-            {
-                setTop(-1);
-                setScoreThreshold(0.5f);
-            }
-        };
+        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+        qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+        qnAMakerEndpoint.setEndpointKey(endpointKey);
+        qnAMakerEndpoint.setHost(hostname);
+
+        QnAMakerOptions options = new QnAMakerOptions();
+        options.setTop(-1);
+        options.setScoreThreshold(0.5f);
+
         Assert.assertThrows(IllegalArgumentException.class, () -> new QnAMaker(qnAMakerEndpoint, options));
     }
 
     @Test
     public void qnaMakerTestEndpointEmptyKbId() {
-        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-            {
-                setKnowledgeBaseId(new String());
-                setEndpointKey(endpointKey);
-                setHost(hostname);
-            }
-        };
+        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+        qnAMakerEndpoint.setKnowledgeBaseId(new String());
+        qnAMakerEndpoint.setEndpointKey(endpointKey);
+        qnAMakerEndpoint.setHost(hostname);
+
         Assert.assertThrows(IllegalArgumentException.class, () -> new QnAMaker(qnAMakerEndpoint, null));
     }
 
     @Test
     public void qnaMakerTestEndpointEmptyEndpointKey() {
-        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-            {
-                setKnowledgeBaseId(knowledgeBaseId);
-                setEndpointKey(new String());
-                setHost(hostname);
-            }
-        };
+        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+        qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+        qnAMakerEndpoint.setEndpointKey(new String());
+        qnAMakerEndpoint.setHost(hostname);
+
         Assert.assertThrows(IllegalArgumentException.class, () -> new QnAMaker(qnAMakerEndpoint, null));
     }
 
     @Test
     public void qnaMakerTestEndpointEmptyHost() {
-        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-            {
-                setKnowledgeBaseId(knowledgeBaseId);
-                setEndpointKey(endpointKey);
-                setHost(new String());
-            }
-        };
+        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+        qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+        qnAMakerEndpoint.setEndpointKey(endpointKey);
+        qnAMakerEndpoint.setHost(new String());
+
         Assert.assertThrows(IllegalArgumentException.class, () -> new QnAMaker(qnAMakerEndpoint, null));
     }
 
@@ -907,13 +828,10 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String host = String.format("{%s}/v2.0", endpoint);
-            QnAMakerEndpoint v2LegacyEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(host);
-                }
-            };
+            QnAMakerEndpoint v2LegacyEndpoint = new QnAMakerEndpoint();
+            v2LegacyEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            v2LegacyEndpoint.setEndpointKey(endpointKey);
+            v2LegacyEndpoint.setHost(host);
 
             Assert.assertThrows(UnsupportedOperationException.class,
                 () -> new QnAMaker(v2LegacyEndpoint,null));
@@ -941,13 +859,10 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String host = String.format("{%s}/v3.0", endpoint);
-            QnAMakerEndpoint v3LegacyEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(host);
-                }
-            };
+            QnAMakerEndpoint v3LegacyEndpoint = new QnAMakerEndpoint();
+            v3LegacyEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            v3LegacyEndpoint.setEndpointKey(endpointKey);
+            v3LegacyEndpoint.setHost(host);
 
             Assert.assertThrows(UnsupportedOperationException.class,
                 () -> new QnAMaker(v3LegacyEndpoint,null));
@@ -975,18 +890,13 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, options);
 
@@ -1018,19 +928,14 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions queryOptionsWithScoreThreshold = new QnAMakerOptions() {
-                {
-                    setScoreThreshold(0.5f);
-                    setTop(2);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions queryOptionsWithScoreThreshold = new QnAMakerOptions();
+            queryOptionsWithScoreThreshold.setScoreThreshold(0.5f);
+            queryOptionsWithScoreThreshold.setTop(2);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, queryOptionsWithScoreThreshold);
 
@@ -1063,13 +968,11 @@ public class QnAMakerTests {
         try {
             String url = this.getRequestUrl();
             String finalEndpoint = String.format("%s:%s", hostname, mockWebServer.url(url).port());
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, null);
             Assert.assertThrows(CompletionException.class, () -> qna.getAnswers(getContext("how do I clean the stove?"), null).join());
         } catch (Exception e) {
@@ -1096,19 +999,14 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                    setIsTest(true);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions();
+            qnaMakerOptions.setTop(1);
+            qnaMakerOptions.setIsTest(true);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, qnaMakerOptions);
 
@@ -1139,19 +1037,14 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                    setRankerType("QuestionOnly");
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions();
+            qnaMakerOptions.setTop(1);
+            qnaMakerOptions.setRankerType("QuestionOnly");
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, qnaMakerOptions);
 
@@ -1183,58 +1076,41 @@ public class QnAMakerTests {
             }
             String finalEndpoint = endpoint;
 
-            QnAMakerOptions noFiltersOptions = new QnAMakerOptions() {
-                {
-                    setTop(30);
-                }
-            };
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            Metadata strictFilterMovie = new Metadata() {
-                {
-                    setName("movie");
-                    setValue("disney");
-                }
-            };
-            Metadata strictFilterHome = new Metadata() {
-                {
-                    setName("home");
-                    setValue("floating");
-                }
-            };
-            Metadata strictFilterDog = new Metadata() {
-                {
-                    setName("dog");
-                    setValue("samoyed");
-                }
-            };
+            QnAMakerOptions noFiltersOptions = new QnAMakerOptions();
+            noFiltersOptions.setTop(30);
+
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            Metadata strictFilterMovie = new Metadata();
+            strictFilterMovie.setName("movie");
+            strictFilterMovie.setValue("disney");
+
+            Metadata strictFilterHome = new Metadata();
+            strictFilterHome.setName("home");
+            strictFilterHome.setValue("floating");
+
+            Metadata strictFilterDog = new Metadata();
+            strictFilterDog.setName("dog");
+            strictFilterDog.setValue("samoyed");
+
             Metadata[] oneStrictFilters = new Metadata[] {strictFilterMovie};
             Metadata[] twoStrictFilters = new Metadata[] {strictFilterMovie, strictFilterHome};
             Metadata[] allChangedRequestOptionsFilters = new Metadata[] {strictFilterDog};
-            QnAMakerOptions oneFilteredOption = new QnAMakerOptions() {
-                {
-                    setTop(30);
-                    setStrictFilters(oneStrictFilters);
-                }
-            };
-            QnAMakerOptions twoStrictFiltersOptions = new QnAMakerOptions() {
-                {
-                    setTop(30);
-                    setStrictFilters(twoStrictFilters);
-                }
-            };
-            QnAMakerOptions allChangedRequestOptions = new QnAMakerOptions() {
-                {
-                    setTop(2000);
-                    setScoreThreshold(0.4f);
-                    setStrictFilters(allChangedRequestOptionsFilters);
-                }
-            };
+            QnAMakerOptions oneFilteredOption = new QnAMakerOptions();
+            oneFilteredOption.setTop(30);
+            oneFilteredOption.setStrictFilters(oneStrictFilters);
+
+            QnAMakerOptions twoStrictFiltersOptions = new QnAMakerOptions();
+            twoStrictFiltersOptions.setTop(30);
+            twoStrictFiltersOptions.setStrictFilters(twoStrictFilters);
+
+            QnAMakerOptions allChangedRequestOptions = new QnAMakerOptions();
+            allChangedRequestOptions.setTop(2000);
+            allChangedRequestOptions.setScoreThreshold(0.4f);
+            allChangedRequestOptions.setStrictFilters(allChangedRequestOptionsFilters);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, noFiltersOptions);
 
@@ -1318,33 +1194,24 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            Metadata strictFilterMovie = new Metadata() {
-                {
-                    setName("movie");
-                    setValue("disney");
-                }
-            };
-            Metadata strictFilterProduction = new Metadata() {
-                {
-                    setName("production");
-                    setValue("Walden");
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            Metadata strictFilterMovie = new Metadata();
+            strictFilterMovie.setName("movie");
+            strictFilterMovie.setValue("disney");
+
+            Metadata strictFilterProduction = new Metadata();
+            strictFilterProduction.setName("production");
+            strictFilterProduction.setValue("Walden");
+
             Metadata[] strictFilters = new Metadata[] {strictFilterMovie, strictFilterProduction};
-            QnAMakerOptions oneFilteredOption = new QnAMakerOptions() {
-                {
-                    setTop(30);
-                    setStrictFilters(strictFilters);
-                    setStrictFiltersJoinOperator(JoinOperator.OR);
-                }
-            };
+            QnAMakerOptions oneFilteredOption = new QnAMakerOptions();
+            oneFilteredOption.setTop(30);
+            oneFilteredOption.setStrictFilters(strictFilters);
+            oneFilteredOption.setStrictFiltersJoinOperator(JoinOperator.OR);
 
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, oneFilteredOption);
 
@@ -1382,19 +1249,13 @@ public class QnAMakerTests {
             }
             String finalEndpoint = endpoint;
 
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
 
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             // Act (Null Telemetry client)
             // This will default to the NullTelemetryClient which no-ops all calls.
@@ -1429,18 +1290,13 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             BotTelemetryClient telemetryClient = Mockito.mock(BotTelemetryClient.class);
 
@@ -1497,18 +1353,13 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             BotTelemetryClient telemetryClient = Mockito.mock(BotTelemetryClient.class);
 
@@ -1565,18 +1416,13 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             BotTelemetryClient telemetryClient = Mockito.mock(BotTelemetryClient.class);
 
@@ -1635,25 +1481,19 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             BotTelemetryClient telemetryClient = Mockito.mock(BotTelemetryClient.class);
 
             // Act - Override the QnaMaker object to log custom stuff and honor parms passed in.
-            Map<String, String> telemetryProperties = new HashMap<String, String>() {{
-                put("Id", "MyID");
-            }};
+            Map<String, String> telemetryProperties = new HashMap<String, String>();
+            telemetryProperties.put("Id", "MyID");
 
             QnAMaker qna = new OverrideTelemetry(qnAMakerEndpoint, options, telemetryClient, false);
             QueryResult[] results = qna.getAnswers(getContext("how do I clean the stove?"), null, telemetryProperties, null).join();
@@ -1709,33 +1549,23 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             BotTelemetryClient telemetryClient = Mockito.mock(BotTelemetryClient.class);
 
             // Act - Pass in properties during QnA invocation
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, options, telemetryClient, false);
-            Map<String, String> telemetryProperties = new HashMap<String, String>() {
-                {
-                    put("MyImportantProperty", "myImportantValue");
-                }
-            };
-            Map<String, Double> telemetryMetrics = new HashMap<String, Double>() {
-                {
-                    put("MyImportantMetric", 3.14159);
-                }
-            };
+            Map<String, String> telemetryProperties = new HashMap<String, String>();
+            telemetryProperties.put("MyImportantProperty", "myImportantValue");
+
+            Map<String, Double> telemetryMetrics = new HashMap<String, Double>();
+            telemetryMetrics.put("MyImportantMetric", 3.14159);
 
             QueryResult[] results = qna.getAnswers(getContext("how do I clean the stove?"), null, telemetryProperties, telemetryMetrics).join();
             // Assert - added properties were added.
@@ -1796,35 +1626,25 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             BotTelemetryClient telemetryClient = Mockito.mock(BotTelemetryClient.class);
 
             // Act - Pass in properties during QnA invocation that override default properties
             //  NOTE: We are invoking this with PII turned OFF, and passing a PII property (originalQuestion).
             QnAMaker qna = new QnAMaker(qnAMakerEndpoint, options, telemetryClient, false);
-            Map<String, String> telemetryProperties = new HashMap<String, String>() {
-                {
-                    put("knowledgeBaseId", "myImportantValue");
-                    put("originalQuestion", "myImportantValue2");
-                }
-            };
-            Map<String, Double> telemetryMetrics = new HashMap<String, Double>() {
-                {
-                    put("score", 3.14159);
-                }
-            };
+            Map<String, String> telemetryProperties = new HashMap<String, String>();
+            telemetryProperties.put("knowledgeBaseId", "myImportantValue");
+            telemetryProperties.put("originalQuestion", "myImportantValue2");
+
+            Map<String, Double> telemetryMetrics = new HashMap<String, Double>();
+            telemetryMetrics.put("score", 3.14159);
 
             QueryResult[] results = qna.getAnswers(getContext("how do I clean the stove?"), null, telemetryProperties, telemetryMetrics).join();
             // Assert - added properties were added.
@@ -1879,18 +1699,13 @@ public class QnAMakerTests {
                 endpoint = String.format("%s:%s", hostname, initializeMockServer(mockWebServer, response, url).port());
             }
             String finalEndpoint = endpoint;
-            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions options = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+            qnAMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnAMakerEndpoint.setEndpointKey(endpointKey);
+            qnAMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions options = new QnAMakerOptions();
+            options.setTop(1);
 
             BotTelemetryClient telemetryClient = Mockito.mock(BotTelemetryClient.class);
 
@@ -1903,17 +1718,12 @@ public class QnAMakerTests {
             //       Logically, the GetAnswersAync should win.  But ultimately OnQnaResultsAsync decides since it is the last
             //       code to touch the properties before logging (since it actually logs the event).
             QnAMaker qna = new OverrideFillTelemetry(qnAMakerEndpoint, options, telemetryClient, false);
-            Map<String, String> telemetryProperties = new HashMap<String, String>() {
-                {
-                    put("knowledgeBaseId", "myImportantValue");
-                    put("matchedQuestion", "myImportantValue2");
-                }
-            };
-            Map<String, Double> telemetryMetrics = new HashMap<String, Double>() {
-                {
-                    put("score", 3.14159);
-                }
-            };
+            Map<String, String> telemetryProperties = new HashMap<String, String>();
+            telemetryProperties.put("knowledgeBaseId", "myImportantValue");
+            telemetryProperties.put("matchedQuestion", "myImportantValue2");
+
+            Map<String, Double> telemetryMetrics = new HashMap<String, Double>();
+            telemetryMetrics.put("score", 3.14159);
 
             QueryResult[] results = qna.getAnswers(getContext("how do I clean the stove?"), null, telemetryProperties, telemetryMetrics).join();
             // Assert - added properties were added.
@@ -1957,15 +1767,11 @@ public class QnAMakerTests {
 
     private static TurnContext getContext(String utterance) {
         TestAdapter b = new TestAdapter();
-        Activity a = new Activity() {
-            {
-                setType(ActivityTypes.MESSAGE);
-                setText(utterance);
-                setConversation(new ConversationAccount());
-                setRecipient(new ChannelAccount());
-                setFrom(new ChannelAccount());
-            }
-        };
+        Activity a = new Activity(ActivityTypes.MESSAGE);
+        a.setText(utterance);
+        a.setConversation(new ConversationAccount());
+        a.setRecipient(new ChannelAccount());
+        a.setFrom(new ChannelAccount());
 
         return new TurnContextImpl(b, a);
     }
@@ -2034,18 +1840,14 @@ public class QnAMakerTests {
             }
             String finalEndpoint = endpoint;
             // Mock Qna
-            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint() {
-                {
-                    setKnowledgeBaseId(knowledgeBaseId);
-                    setEndpointKey(endpointKey);
-                    setHost(finalEndpoint);
-                }
-            };
-            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions() {
-                {
-                    setTop(1);
-                }
-            };
+            QnAMakerEndpoint qnaMakerEndpoint = new QnAMakerEndpoint();
+            qnaMakerEndpoint.setKnowledgeBaseId(knowledgeBaseId);
+            qnaMakerEndpoint.setEndpointKey(endpointKey);
+            qnaMakerEndpoint.setHost(finalEndpoint);
+
+            QnAMakerOptions qnaMakerOptions = new QnAMakerOptions();
+            qnaMakerOptions.setTop(1);
+
             return new QnAMaker(qnaMakerEndpoint, qnaMakerOptions);
         } catch (Exception e) {
             return null;
@@ -2144,11 +1946,9 @@ public class QnAMakerTests {
                 telemetryClient.trackEvent(QnATelemetryConstants.QNA_MSG_EVENT, eventData.getLeft(), eventData.getRight());
 
                 // Create second event.
-                Map<String, String> secondEventProperties = new HashMap<String, String>(){
-                    {
-                        put("MyImportantProperty2", "myImportantValue2");
-                    }
-                };
+                Map<String, String> secondEventProperties = new HashMap<String, String>();
+                secondEventProperties.put("MyImportantProperty2", "myImportantValue2");
+
                 telemetryClient.trackEvent("MySecondEvent", secondEventProperties);
             });
         }

--- a/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTraceInfoTests.java
+++ b/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTraceInfoTests.java
@@ -17,22 +17,17 @@ public class QnAMakerTraceInfoTests {
 
     @Test
     public void qnaMakerTraceInfoSerialization() throws IOException {
-        QueryResult[] queryResults = new QueryResult[] { new QueryResult() {
-            {
-                setQuestions(new String[] { "What's your name?" });
-                setAnswer("My name is Mike");
-                setScore(0.9f);
-            }
-        } };
+        QueryResult queryResult = new QueryResult();
+        queryResult.setQuestions(new String[] { "What's your name?" });
+        queryResult.setAnswer("My name is Mike");
+        queryResult.setScore(0.9f);
+        QueryResult[] queryResults = new QueryResult[] { queryResult };
 
-        QnAMakerTraceInfo qnaMakerTraceInfo = new QnAMakerTraceInfo() {
-            {
-                setQueryResults(queryResults);
-                setKnowledgeBaseId(UUID.randomUUID().toString());
-                setScoreThreshold(0.5f);
-                setTop(1);
-            }
-        };
+        QnAMakerTraceInfo qnaMakerTraceInfo = new QnAMakerTraceInfo();
+        qnaMakerTraceInfo.setQueryResults(queryResults);
+        qnaMakerTraceInfo.setKnowledgeBaseId(UUID.randomUUID().toString());
+        qnaMakerTraceInfo.setScoreThreshold(0.5f);
+        qnaMakerTraceInfo.setTop(1);
 
         JacksonAdapter jacksonAdapter = new JacksonAdapter();
         String serialized = jacksonAdapter.serialize(qnaMakerTraceInfo);

--- a/libraries/bot-azure/src/main/java/com/microsoft/bot/azure/CosmosDbPartitionedStorage.java
+++ b/libraries/bot-azure/src/main/java/com/microsoft/bot/azure/CosmosDbPartitionedStorage.java
@@ -206,20 +206,17 @@ public class CosmosDbPartitionedStorage implements Storage {
                     // metadata.
                     node.remove("eTag");
 
-                    DocumentStoreItem documentChange = new DocumentStoreItem() {
-                        {
-                            setId(
-                                CosmosDbKeyEscape.escapeKey(
-                                    change.getKey(),
-                                    cosmosDbStorageOptions.getKeySuffix(),
-                                    cosmosDbStorageOptions.getCompatibilityMode()
-                                )
-                            );
-                            setReadId(change.getKey());
-                            setDocument(node.toString());
-                            setType(change.getValue().getClass().getTypeName());
-                        }
-                    };
+                    DocumentStoreItem documentChange = new DocumentStoreItem();
+                    documentChange.setId(
+                        CosmosDbKeyEscape.escapeKey(
+                            change.getKey(),
+                            cosmosDbStorageOptions.getKeySuffix(),
+                            cosmosDbStorageOptions.getCompatibilityMode()
+                        )
+                    );
+                    documentChange.setReadId(change.getKey());
+                    documentChange.setDocument(node.toString());
+                    documentChange.setType(change.getValue().getClass().getTypeName());
 
                     Document document = new Document(objectMapper.writeValueAsString(documentChange));
 
@@ -349,11 +346,8 @@ public class CosmosDbPartitionedStorage implements Storage {
                         partitionKeyDefinition.setPaths(Collections.singleton(DocumentStoreItem.PARTITION_KEY_PATH));
                         collectionDefinition.setPartitionKey(partitionKeyDefinition);
 
-                        RequestOptions options = new RequestOptions() {
-                            {
-                                setOfferThroughput(cosmosDbStorageOptions.getContainerThroughput());
-                            }
-                        };
+                        RequestOptions options = new RequestOptions();
+                        options.setOfferThroughput(cosmosDbStorageOptions.getContainerThroughput());
 
                         collectionCache = client
                             .createCollection(getDatabase().getSelfLink(), collectionDefinition, options)

--- a/libraries/bot-azure/src/test/java/com/microsoft/bot/azure/CosmosDbPartitionStorageTests.java
+++ b/libraries/bot-azure/src/test/java/com/microsoft/bot/azure/CosmosDbPartitionStorageTests.java
@@ -91,12 +91,12 @@ public class CosmosDbPartitionStorageTests extends StorageBaseTests {
     @Before
     public void testInit() {
         if (emulatorIsRunning) {
-            storage = new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions() {{
-                setAuthKey(CosmosAuthKey);
-                setContainerId(CosmosCollectionName);
-                setCosmosDbEndpoint(CosmosServiceEndpoint);
-                setDatabaseId(CosmosDatabaseName);
-            }});
+            CosmosDbPartitionedStorageOptions options = new CosmosDbPartitionedStorageOptions();
+            options.setAuthKey(CosmosAuthKey);
+            options.setContainerId(CosmosCollectionName);
+            options.setCosmosDbEndpoint(CosmosServiceEndpoint);
+            options.setDatabaseId(CosmosDatabaseName);
+            storage = new CosmosDbPartitionedStorage(options);
         }
     }
 
@@ -115,75 +115,75 @@ public class CosmosDbPartitionStorageTests extends StorageBaseTests {
         }
 
         try {
-            new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions() {{
-                setAuthKey("test");
-                setContainerId("testId");
-                setDatabaseId("testDb");
-            }});
+            CosmosDbPartitionedStorageOptions options = new CosmosDbPartitionedStorageOptions();
+            options.setAuthKey("test");
+            options.setContainerId("testId");
+            options.setDatabaseId("testDb");
+            new CosmosDbPartitionedStorage(options);
             Assert.fail("should have thrown for missing end point");
         } catch (IllegalArgumentException e) {
 
         }
 
         try {
-            new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions() {{
-                setAuthKey(null);
-                setContainerId("testId");
-                setDatabaseId("testDb");
-                setCosmosDbEndpoint("testEndpoint");
-            }});
+            CosmosDbPartitionedStorageOptions options = new CosmosDbPartitionedStorageOptions();
+            options.setAuthKey(null);
+            options.setContainerId("testId");
+            options.setDatabaseId("testDb");
+            options.setCosmosDbEndpoint("testEndpoint");
+            new CosmosDbPartitionedStorage(options);
             Assert.fail("should have thrown for missing auth key");
         } catch (IllegalArgumentException e) {
 
         }
 
         try {
-            new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions() {{
-                setAuthKey("testAuthKey");
-                setContainerId("testId");
-                setDatabaseId(null);
-                setCosmosDbEndpoint("testEndpoint");
-            }});
+            CosmosDbPartitionedStorageOptions options = new CosmosDbPartitionedStorageOptions();
+            options.setAuthKey("testAuthKey");
+            options.setContainerId("testId");
+            options.setDatabaseId(null);
+            options.setCosmosDbEndpoint("testEndpoint");
+            new CosmosDbPartitionedStorage(options);
             Assert.fail("should have thrown for missing db id");
         } catch (IllegalArgumentException e) {
 
         }
 
         try {
-            new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions() {{
-                setAuthKey("testAuthKey");
-                setContainerId(null);
-                setDatabaseId("testDb");
-                setCosmosDbEndpoint("testEndpoint");
-            }});
+            CosmosDbPartitionedStorageOptions options = new CosmosDbPartitionedStorageOptions();
+            options.setAuthKey("testAuthKey");
+            options.setContainerId(null);
+            options.setDatabaseId("testDb");
+            options.setCosmosDbEndpoint("testEndpoint");
+            new CosmosDbPartitionedStorage(options);
             Assert.fail("should have thrown for missing collection id");
         } catch (IllegalArgumentException e) {
 
         }
 
         try {
-            new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions() {{
-                setAuthKey("testAuthKey");
-                setContainerId("testId");
-                setDatabaseId("testDb");
-                setCosmosDbEndpoint("testEndpoint");
-                setKeySuffix("?#*test");
-                setCompatibilityMode(false);
-            }});
+            CosmosDbPartitionedStorageOptions options = new CosmosDbPartitionedStorageOptions();
+            options.setAuthKey("testAuthKey");
+            options.setContainerId("testId");
+            options.setDatabaseId("testDb");
+            options.setCosmosDbEndpoint("testEndpoint");
+            options.setKeySuffix("?#*test");
+            options.setCompatibilityMode(false);
+            new CosmosDbPartitionedStorage(options);
             Assert.fail("should have thrown for invalid Row Key characters in KeySuffix");
         } catch (IllegalArgumentException e) {
 
         }
 
         try {
-            new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions() {{
-                setAuthKey("testAuthKey");
-                setContainerId("testId");
-                setDatabaseId("testDb");
-                setCosmosDbEndpoint("testEndpoint");
-                setKeySuffix("thisisatest");
-                setCompatibilityMode(true);
-            }});
+            CosmosDbPartitionedStorageOptions options = new CosmosDbPartitionedStorageOptions();
+            options.setAuthKey("testAuthKey");
+            options.setContainerId("testId");
+            options.setDatabaseId("testDb");
+            options.setCosmosDbEndpoint("testEndpoint");
+            options.setKeySuffix("thisisatest");
+            options.setCompatibilityMode(true);
+            new CosmosDbPartitionedStorage(options);
             Assert.fail("should have thrown for CompatibilityMode 'true' while using a KeySuffix");
         } catch (IllegalArgumentException e) {
 

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotFrameworkAdapter.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotFrameworkAdapter.java
@@ -1060,13 +1060,10 @@ public class BotFrameworkAdapter extends BotAdapter
                     // run pipeline
                     CompletableFuture<Void> result = new CompletableFuture<>();
                     try (TurnContextImpl context = new TurnContextImpl(this, eventActivity)) {
-                        HashMap<String, String> claims = new HashMap<String, String>() {
-                            {
-                                put(AuthenticationConstants.AUDIENCE_CLAIM, credentials.getAppId());
-                                put(AuthenticationConstants.APPID_CLAIM, credentials.getAppId());
-                                put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-                            }
-                        };
+                        HashMap<String, String> claims = new HashMap<String, String>();
+                        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, credentials.getAppId());
+                        claims.put(AuthenticationConstants.APPID_CLAIM, credentials.getAppId());
+                        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
                         ClaimsIdentity claimsIdentity = new ClaimsIdentity("anonymous", claims);
 
                         context.getTurnState().add(BOT_IDENTITY_KEY, claimsIdentity);
@@ -1531,24 +1528,19 @@ public class BotFrameworkAdapter extends BotAdapter
             try {
                 Activity activity = context.getActivity();
                 String appId = getBotAppId(context);
+                ConversationReference conversationReference = new ConversationReference();
+                conversationReference.setActivityId(activity.getId());
+                conversationReference.setBot(activity.getRecipient());
+                conversationReference.setChannelId(activity.getChannelId());
+                conversationReference.setConversation(activity.getConversation());
+                conversationReference.setServiceUrl(activity.getServiceUrl());
+                conversationReference.setUser(activity.getFrom());
 
-                TokenExchangeState tokenExchangeState = new TokenExchangeState() {
-                    {
-                        setConnectionName(connectionName);
-                        setConversation(new ConversationReference() {
-                            {
-                                setActivityId(activity.getId());
-                                setBot(activity.getRecipient());
-                                setChannelId(activity.getChannelId());
-                                setConversation(activity.getConversation());
-                                setServiceUrl(activity.getServiceUrl());
-                                setUser(activity.getFrom());
-                            }
-                        });
-                        setRelatesTo(activity.getRelatesTo());
-                        setMsAppId(appId);
-                    }
-                };
+                TokenExchangeState tokenExchangeState = new TokenExchangeState();
+                tokenExchangeState.setConnectionName(connectionName);
+                tokenExchangeState.setConversation(conversationReference);
+                tokenExchangeState.setRelatesTo(activity.getRelatesTo());
+                tokenExchangeState.setMsAppId(appId);
 
                 String serializedState = Serialization.toString(tokenExchangeState);
                 String state = Base64.getEncoder().encodeToString(serializedState.getBytes(StandardCharsets.UTF_8));
@@ -1598,24 +1590,19 @@ public class BotFrameworkAdapter extends BotAdapter
                 Activity activity = context.getActivity();
                 String appId = getBotAppId(context);
 
-                TokenExchangeState tokenExchangeState = new TokenExchangeState() {
-                    {
-                        setConnectionName(connectionName);
-                        setConversation(new ConversationReference() {
-                            {
-                                setActivityId(activity.getId());
-                                setBot(activity.getRecipient());
-                                setChannelId(activity.getChannelId());
-                                setConversation(activity.getConversation());
-                                setLocale(activity.getLocale());
-                                setServiceUrl(activity.getServiceUrl());
-                                setUser(activity.getFrom());
-                            }
-                        });
-                        setRelatesTo(activity.getRelatesTo());
-                        setMsAppId(appId);
-                    }
-                };
+                ConversationReference conversationReference = new ConversationReference();
+                conversationReference.setActivityId(activity.getId());
+                conversationReference.setBot(activity.getRecipient());
+                conversationReference.setChannelId(activity.getChannelId());
+                conversationReference.setConversation(activity.getConversation());
+                conversationReference.setLocale(activity.getLocale());
+                conversationReference.setServiceUrl(activity.getServiceUrl());
+                conversationReference.setUser(activity.getFrom());
+                TokenExchangeState tokenExchangeState = new TokenExchangeState();
+                tokenExchangeState.setConnectionName(connectionName);
+                tokenExchangeState.setConversation(conversationReference);
+                tokenExchangeState.setRelatesTo(activity.getRelatesTo());
+                tokenExchangeState.setMsAppId(appId);
 
                 String serializedState = Serialization.toString(tokenExchangeState);
                 String state = Base64.getEncoder().encodeToString(serializedState.getBytes(StandardCharsets.UTF_8));
@@ -1827,24 +1814,19 @@ public class BotFrameworkAdapter extends BotAdapter
                 Activity activity = context.getActivity();
                 String appId = getBotAppId(context);
 
-                TokenExchangeState tokenExchangeState = new TokenExchangeState() {
-                    {
-                        setConnectionName(connectionName);
-                        setConversation(new ConversationReference() {
-                            {
-                                setActivityId(activity.getId());
-                                setBot(activity.getRecipient());
-                                setChannelId(activity.getChannelId());
-                                setConversation(activity.getConversation());
-                                setLocale(activity.getLocale());
-                                setServiceUrl(activity.getServiceUrl());
-                                setUser(activity.getFrom());
-                            }
-                        });
-                        setRelatesTo(activity.getRelatesTo());
-                        setMsAppId(appId);
-                    }
-                };
+                ConversationReference conversationReference = new ConversationReference();
+                conversationReference.setActivityId(activity.getId());
+                conversationReference.setBot(activity.getRecipient());
+                conversationReference.setChannelId(activity.getChannelId());
+                conversationReference.setConversation(activity.getConversation());
+                conversationReference.setLocale(activity.getLocale());
+                conversationReference.setServiceUrl(activity.getServiceUrl());
+                conversationReference.setUser(activity.getFrom());
+                TokenExchangeState tokenExchangeState = new TokenExchangeState();
+                tokenExchangeState.setConnectionName(connectionName);
+                tokenExchangeState.setConversation(conversationReference);
+                tokenExchangeState.setRelatesTo(activity.getRelatesTo());
+                tokenExchangeState.setMsAppId(appId);
 
                 String serializedState = Serialization.toString(tokenExchangeState);
                 String state = Base64.getEncoder().encodeToString(serializedState.getBytes(StandardCharsets.UTF_8));

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotState.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotState.java
@@ -147,11 +147,8 @@ public abstract class BotState implements PropertyManager {
             CachedBotState cachedState = turnContext.getTurnState().get(contextServiceKey);
             if (force || cachedState != null && cachedState.isChanged()) {
                 String storageKey = getStorageKey(turnContext);
-                Map<String, Object> changes = new HashMap<String, Object>() {
-                    {
-                        put(storageKey, cachedState.state);
-                    }
-                };
+                Map<String, Object> changes = new HashMap<String, Object>();
+                changes.put(storageKey, cachedState.state);
 
                 return storage.write(changes).thenApply(val -> {
                     cachedState.setHash(cachedState.computeHash(cachedState.state));

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/MessageFactory.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/MessageFactory.java
@@ -135,14 +135,10 @@ public final class MessageFactory {
 
         List<CardAction> cardActions = new ArrayList<>();
         for (String action : actions) {
-            CardAction cardAction = new CardAction() {
-                {
-                    setType(ActionTypes.IM_BACK);
-                    setValue(action);
-                    setTitle(action);
-                }
-            };
-
+            CardAction cardAction = new CardAction();
+            cardAction.setType(ActionTypes.IM_BACK);
+            cardAction.setValue(action);
+            cardAction.setTitle(action);
             cardActions.add(cardAction);
         }
 
@@ -357,13 +353,10 @@ public final class MessageFactory {
             throw new IllegalArgumentException("contentType cannot be null or empty");
         }
 
-        Attachment attachment = new Attachment() {
-            {
-                setContentType(contentType);
-                setContentUrl(url);
-                setName(StringUtils.isEmpty(name) ? null : name);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContentType(contentType);
+        attachment.setContentUrl(url);
+        attachment.setName(StringUtils.isEmpty(name) ? null : name);
 
         return attachmentActivity(
             AttachmentLayoutTypes.LIST, Collections.singletonList(attachment), text, ssml, inputHint

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/ShowTypingMiddleware.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/ShowTypingMiddleware.java
@@ -119,11 +119,8 @@ public class ShowTypingMiddleware implements Middleware {
     ) {
         // create a TypingActivity, associate it with the conversation and send
         // immediately
-        Activity typingActivity = new Activity(ActivityTypes.TYPING) {
-            {
-                setRelatesTo(turnContext.getActivity().getRelatesTo());
-            }
-        };
+        Activity typingActivity = new Activity(ActivityTypes.TYPING);
+        typingActivity.setRelatesTo(turnContext.getActivity().getRelatesTo());
 
         // sending the Activity directly on the Adapter avoids other Middleware and
         // avoids setting the Responded

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TelemetryLoggerMiddleware.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TelemetryLoggerMiddleware.java
@@ -102,12 +102,9 @@ public class TelemetryLoggerMiddleware implements Middleware {
             context.onDeleteActivity(
                 (deleteContext, deleteReference, deleteNext) -> deleteNext.get()
                     .thenCompose(nextResult -> {
-                        Activity deleteActivity = new Activity(ActivityTypes.MESSAGE_DELETE) {
-                            {
-                                setId(deleteReference.getActivityId());
-                                applyConversationReference(deleteReference, false);
-                            }
-                        };
+                        Activity deleteActivity = new Activity(ActivityTypes.MESSAGE_DELETE);
+                        deleteActivity.setId(deleteReference.getActivityId());
+                        deleteActivity.applyConversationReference(deleteReference, false);
 
                         return onDeleteActivity(deleteActivity);
                     })
@@ -196,18 +193,15 @@ public class TelemetryLoggerMiddleware implements Middleware {
         Map<String, String> additionalProperties
     ) {
 
-        Map<String, String> properties = new HashMap<String, String>() {
-            {
-                put(TelemetryConstants.FROMIDPROPERTY, activity.getFrom().getId());
-                put(
-                    TelemetryConstants.CONVERSATIONNAMEPROPERTY,
-                    activity.getConversation().getName()
-                );
-                put(TelemetryConstants.LOCALEPROPERTY, activity.getLocale());
-                put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
-                put(TelemetryConstants.RECIPIENTNAMEPROPERTY, activity.getRecipient().getName());
-            }
-        };
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put(TelemetryConstants.FROMIDPROPERTY, activity.getFrom().getId());
+        properties.put(
+            TelemetryConstants.CONVERSATIONNAMEPROPERTY,
+            activity.getConversation().getName()
+        );
+        properties.put(TelemetryConstants.LOCALEPROPERTY, activity.getLocale());
+        properties.put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
+        properties.put(TelemetryConstants.RECIPIENTNAMEPROPERTY, activity.getRecipient().getName());
 
         // Use the LogPersonalInformation flag to toggle logging PII data, text and user
         // name are common examples
@@ -250,17 +244,14 @@ public class TelemetryLoggerMiddleware implements Middleware {
         Map<String, String> additionalProperties
     ) {
 
-        Map<String, String> properties = new HashMap<String, String>() {
-            {
-                put(TelemetryConstants.REPLYACTIVITYIDPROPERTY, activity.getReplyToId());
-                put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
-                put(
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put(TelemetryConstants.REPLYACTIVITYIDPROPERTY, activity.getReplyToId());
+        properties.put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
+        properties.put(
                     TelemetryConstants.CONVERSATIONNAMEPROPERTY,
                     activity.getConversation().getName()
-                );
-                put(TelemetryConstants.LOCALEPROPERTY, activity.getLocale());
-            }
-        };
+        );
+        properties.put(TelemetryConstants.LOCALEPROPERTY, activity.getLocale());
 
         // Use the LogPersonalInformation flag to toggle logging PII data, text and user
         // name are common examples
@@ -303,17 +294,14 @@ public class TelemetryLoggerMiddleware implements Middleware {
         Map<String, String> additionalProperties
     ) {
 
-        Map<String, String> properties = new HashMap<String, String>() {
-            {
-                put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
-                put(TelemetryConstants.CONVERSATIONIDPROPERTY, activity.getConversation().getId());
-                put(
-                    TelemetryConstants.CONVERSATIONNAMEPROPERTY,
-                    activity.getConversation().getName()
-                );
-                put(TelemetryConstants.LOCALEPROPERTY, activity.getLocale());
-            }
-        };
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
+        properties.put(TelemetryConstants.CONVERSATIONIDPROPERTY, activity.getConversation().getId());
+        properties.put(
+            TelemetryConstants.CONVERSATIONNAMEPROPERTY,
+            activity.getConversation().getName()
+        );
+        properties.put(TelemetryConstants.LOCALEPROPERTY, activity.getLocale());
 
         // Use the LogPersonalInformation flag to toggle logging PII data, text is a
         // common example
@@ -344,16 +332,13 @@ public class TelemetryLoggerMiddleware implements Middleware {
         Map<String, String> additionalProperties
     ) {
 
-        Map<String, String> properties = new HashMap<String, String>() {
-            {
-                put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
-                put(TelemetryConstants.CONVERSATIONIDPROPERTY, activity.getConversation().getId());
-                put(
-                    TelemetryConstants.CONVERSATIONNAMEPROPERTY,
-                    activity.getConversation().getName()
-                );
-            }
-        };
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put(TelemetryConstants.RECIPIENTIDPROPERTY, activity.getRecipient().getId());
+        properties.put(TelemetryConstants.CONVERSATIONIDPROPERTY, activity.getConversation().getId());
+        properties.put(
+            TelemetryConstants.CONVERSATIONNAMEPROPERTY,
+            activity.getConversation().getName()
+        );
 
         // Additional Properties can override "stock" properties.
         if (additionalProperties != null) {

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TranscriptLoggerMiddleware.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TranscriptLoggerMiddleware.java
@@ -113,12 +113,9 @@ public class TranscriptLoggerMiddleware implements Middleware {
                 return nextDel.get().thenApply(nextDelResult -> {
                     // add MessageDelete activity
                     // log as MessageDelete activity
-                    Activity deleteActivity = new Activity(ActivityTypes.MESSAGE_DELETE) {
-                        {
-                            setId(reference.getActivityId());
-                            applyConversationReference(reference, false);
-                        }
-                    };
+                    Activity deleteActivity = new Activity(ActivityTypes.MESSAGE_DELETE);
+                    deleteActivity.setId(reference.getActivityId());
+                    deleteActivity.applyConversationReference(reference, false);
 
                     logActivity(deleteActivity, false);
 

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TurnContextImpl.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TurnContextImpl.java
@@ -312,11 +312,8 @@ public class TurnContextImpl implements TurnContext, AutoCloseable {
             return Async.completeExceptionally(new IllegalArgumentException("textReplyToSend"));
         }
 
-        Activity activityToSend = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setText(textReplyToSend);
-            }
-        };
+        Activity activityToSend = new Activity(ActivityTypes.MESSAGE);
+        activityToSend.setText(textReplyToSend);
 
         if (StringUtils.isNotEmpty(speak)) {
             activityToSend.setSpeak(speak);

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/ActivityHandlerTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/ActivityHandlerTests.java
@@ -39,12 +39,8 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestInstallationUpdateAdd() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.INSTALLATION_UPDATE);
-                setAction("add");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INSTALLATION_UPDATE);
+        activity.setAction("add");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -58,12 +54,8 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestInstallationUpdateAddUpgrade() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.INSTALLATION_UPDATE);
-                setAction("add-upgrade");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INSTALLATION_UPDATE);
+        activity.setAction("add-upgrade");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -77,12 +69,8 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestInstallationUpdateRemove() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.INSTALLATION_UPDATE);
-                setAction("remove");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INSTALLATION_UPDATE);
+        activity.setAction("remove");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -96,12 +84,8 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestInstallationUpdateRemoveUpgrade() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.INSTALLATION_UPDATE);
-                setAction("remove-upgrade");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INSTALLATION_UPDATE);
+        activity.setAction("remove-upgrade");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -127,17 +111,11 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberAdded1() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("b"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("b"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -150,18 +128,13 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberAdded2() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("b"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        activity.setType(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("b"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -175,19 +148,13 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberAdded3() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("b"));
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("b"));
+        members.add(new ChannelAccount("c"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -201,17 +168,11 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberRemoved1() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -224,18 +185,12 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberRemoved2() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -249,19 +204,13 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberRemoved3() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("b"));
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("b"));
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -275,17 +224,11 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberAddedJustTheBot() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("b"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("b"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -298,17 +241,11 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestMemberRemovedJustTheBot() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -326,21 +263,13 @@ public class ActivityHandlerTests {
         // sends separate activities each with a single add and a single remove.
 
         // Arrange
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.MESSAGE_REACTION);
-                setReactionsAdded(new ArrayList<MessageReaction>() {
-                    {
-                        add(new MessageReaction("sad"));
-                    }
-                });
-                setReactionsRemoved(new ArrayList<MessageReaction>() {
-                    {
-                        add(new MessageReaction("angry"));
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE_REACTION);
+        ArrayList<MessageReaction> reactionsAdded = new ArrayList<MessageReaction>();
+        reactionsAdded.add(new MessageReaction("sad"));
+        activity.setReactionsAdded(reactionsAdded);
+        ArrayList<MessageReaction> reactionsRemoved = new ArrayList<MessageReaction>();
+        reactionsRemoved.add(new MessageReaction("angry"));
+        activity.setReactionsRemoved(reactionsRemoved);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -355,12 +284,8 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestTokenResponseEventAsync() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.EVENT);
-                setName("tokens/response");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.EVENT);
+        activity.setName("tokens/response");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -374,12 +299,8 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestEventAsync() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.EVENT);
-                setName("some.random.event");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.EVENT);
+        activity.setName("some.random.event");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -393,11 +314,7 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestEventNullNameAsync() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.EVENT);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.EVENT);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -447,11 +364,7 @@ public class ActivityHandlerTests {
 
     @Test
     public void TestUnrecognizedActivityType() {
-        Activity activity = new Activity() {
-            {
-                setType("shall.not.pass");
-            }
-        };
+        Activity activity = new Activity("shall.not.pass");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/BotAdapterTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/BotAdapterTests.java
@@ -73,36 +73,27 @@ public class BotAdapterTests {
         boolean[] callbackInvoked = new boolean[] { false };
 
         TestAdapter adapter = new TestAdapter();
-        ConversationReference cr = new ConversationReference() {
-            {
-                setActivityId("activityId");
-                setBot(new ChannelAccount() {
-                    {
-                        setId("channelId");
-                        setName("testChannelAccount");
-                        setRole(RoleTypes.BOT);
-                    }
-                });
-                setChannelId("testChannel");
-                setServiceUrl("testUrl");
-                setConversation(new ConversationAccount() {
-                    {
-                        setConversationType("");
-                        setId("testConversationId");
-                        setIsGroup(false);
-                        setName("testConversationName");
-                        setRole(RoleTypes.USER);
-                    }
-                });
-                setUser(new ChannelAccount() {
-                    {
-                        setId("channelId");
-                        setName("testChannelAccount");
-                        setRole(RoleTypes.BOT);
-                    }
-                });
-            }
-        };
+        ConversationReference cr = new ConversationReference();
+        cr.setActivityId("activityId");
+        ChannelAccount botAccount = new ChannelAccount();
+        botAccount.setId("channelId");
+        botAccount.setName("testChannelAccount");
+        botAccount.setRole(RoleTypes.BOT);
+        cr.setBot(botAccount);
+        cr.setChannelId("testChannel");
+        cr.setServiceUrl("testUrl");
+        ConversationAccount conversation = new ConversationAccount();
+        conversation.setConversationType("");
+        conversation.setId("testConversationId");
+        conversation.setIsGroup(false);
+        conversation.setName("testConversationName");
+        conversation.setRole(RoleTypes.USER);
+        cr.setConversation(conversation);
+        ChannelAccount userAccount = new ChannelAccount();
+        userAccount.setId("channelId");
+        userAccount.setName("testChannelAccount");
+        userAccount.setRole(RoleTypes.BOT);
+        cr.setUser(userAccount);
 
         BotCallbackHandler callback = (turnContext) -> {
             callbackInvoked[0] = true;

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/InspectionTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/InspectionTests.java
@@ -183,19 +183,11 @@ public class InspectionTests {
         String attachCommand = "<at>" + recipientId + "</at> "
             + inspectionOpenResultActivity.getValue();
         Activity attachActivity = MessageFactory.text(attachCommand);
-        attachActivity.getEntities().add(new Entity() {
-            {
-                setType("mention");
-                getProperties().put(
-                    "text",
-                    JsonNodeFactory.instance.textNode("<at>" + recipientId + "</at>")
-                );
-                getProperties().put(
-                    "mentioned",
-                    JsonNodeFactory.instance.objectNode().put("id", "bot")
-                );
-            }
-        });
+        Entity entity = new Entity();
+        entity.setType("mention");
+        entity.getProperties().put("text", JsonNodeFactory.instance.textNode("<at>" + recipientId + "</at>"));
+        entity.getProperties().put("mentioned", JsonNodeFactory.instance.objectNode().put("id", "bot"));
+        attachActivity.getEntities().add(entity);
 
         applicationAdapter.processActivity(
             attachActivity,

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MemoryConversations.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MemoryConversations.java
@@ -48,11 +48,9 @@ public class MemoryConversations implements Conversations {
         Activity activity
     ) {
         sentActivities.add(activity);
-        return CompletableFuture.completedFuture(new ResourceResponse() {
-            {
-                setId(activity.getId());
-            }
-        });
+        ResourceResponse response = new ResourceResponse();
+        response.setId(activity.getId());
+        return CompletableFuture.completedFuture(response);
     }
 
     @Override
@@ -69,11 +67,9 @@ public class MemoryConversations implements Conversations {
         Activity activity
     ) {
         sentActivities.add(activity);
-        return CompletableFuture.completedFuture(new ResourceResponse() {
-            {
-                setId(activity.getId());
-            }
-        });
+        ResourceResponse response = new ResourceResponse();
+        response.setId(activity.getId());
+        return CompletableFuture.completedFuture(response);
     }
 
     @Override

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MessageFactoryTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/MessageFactoryTests.java
@@ -137,13 +137,10 @@ public class MessageFactoryTests {
         String cardActionValue = UUID.randomUUID().toString();
         String cardActionTitle = UUID.randomUUID().toString();
 
-        CardAction ca = new CardAction() {
-            {
-                setType(ActionTypes.IM_BACK);
-                setValue(cardActionValue);
-                setTitle(cardActionTitle);
-            }
-        };
+        CardAction ca = new CardAction();
+        ca.setType(ActionTypes.IM_BACK);
+        ca.setValue(cardActionValue);
+        ca.setTitle(cardActionTitle);
 
         List<CardAction> cardActions = Collections.singletonList(ca);
 
@@ -178,24 +175,18 @@ public class MessageFactoryTests {
         String cardValue1 = UUID.randomUUID().toString();
         String cardTitle1 = UUID.randomUUID().toString();
 
-        CardAction cardAction1 = new CardAction() {
-            {
-                setType(ActionTypes.IM_BACK);
-                setValue(cardValue1);
-                setTitle(cardTitle1);
-            }
-        };
+        CardAction cardAction1 = new CardAction();
+        cardAction1.setType(ActionTypes.IM_BACK);
+        cardAction1.setValue(cardValue1);
+        cardAction1.setTitle(cardTitle1);
 
         String cardValue2 = UUID.randomUUID().toString();
         String cardTitle2 = UUID.randomUUID().toString();
 
-        CardAction cardAction2 = new CardAction() {
-            {
-                setType(ActionTypes.IM_BACK);
-                setValue(cardValue2);
-                setTitle(cardTitle2);
-            }
-        };
+        CardAction cardAction2 = new CardAction();
+        cardAction2.setType(ActionTypes.IM_BACK);
+        cardAction2.setValue(cardValue2);
+        cardAction2.setTitle(cardTitle2);
 
         List<CardAction> cardActions = Arrays.asList(cardAction1, cardAction2);
         Set<String> values = new HashSet<>(Arrays.asList(cardValue1, cardValue2));
@@ -238,11 +229,8 @@ public class MessageFactoryTests {
         InputHints inputHint = InputHints.EXPECTING_INPUT;
 
         String attachmentName = UUID.randomUUID().toString();
-        Attachment a = new Attachment() {
-            {
-                setName(attachmentName);
-            }
-        };
+        Attachment a = new Attachment();
+        a.setName(attachmentName);
 
         Activity message = MessageFactory.attachment(a, text, ssml, inputHint);
 
@@ -283,18 +271,12 @@ public class MessageFactoryTests {
         InputHints inputHint = InputHints.EXPECTING_INPUT;
 
         String attachmentName = UUID.randomUUID().toString();
-        Attachment attachment1 = new Attachment() {
-            {
-                setName(attachmentName);
-            }
-        };
+        Attachment attachment1 = new Attachment();
+        attachment1.setName(attachmentName);
 
         String attachmentName2 = UUID.randomUUID().toString();
-        Attachment attachment2 = new Attachment() {
-            {
-                setName(attachmentName2);
-            }
-        };
+        Attachment attachment2 = new Attachment();
+        attachment2.setName(attachmentName2);
 
         List<Attachment> multipleAttachments = Arrays.asList(attachment1, attachment2);
         Activity message = MessageFactory.carousel(multipleAttachments, text, ssml, inputHint);
@@ -324,18 +306,12 @@ public class MessageFactoryTests {
         InputHints inputHint = InputHints.EXPECTING_INPUT;
 
         String attachmentName1 = UUID.randomUUID().toString();
-        Attachment attachment1 = new Attachment() {
-            {
-                setName(attachmentName1);
-            }
-        };
+        Attachment attachment1 = new Attachment();
+        attachment1.setName(attachmentName1);
 
         String attachmentName2 = UUID.randomUUID().toString();
-        Attachment attachment2 = new Attachment() {
-            {
-                setName(attachmentName2);
-            }
-        };
+        Attachment attachment2 = new Attachment();
+        attachment2.setName(attachmentName2);
 
         Set<Attachment> multipleAttachments = new HashSet<>(
             Arrays.asList(attachment1, attachment2)
@@ -368,18 +344,12 @@ public class MessageFactoryTests {
         InputHints inputHint = InputHints.EXPECTING_INPUT;
 
         String attachmentName = UUID.randomUUID().toString();
-        Attachment a = new Attachment() {
-            {
-                setName(attachmentName);
-            }
-        };
+        Attachment a = new Attachment();
+        a.setName(attachmentName);
 
         String attachmentName2 = UUID.randomUUID().toString();
-        Attachment a2 = new Attachment() {
-            {
-                setName(attachmentName2);
-            }
-        };
+        Attachment a2 = new Attachment();
+        a2.setName(attachmentName2);
 
         List<Attachment> multipleAttachments = Arrays.asList(a, a2);
         Activity message = MessageFactory.attachment(multipleAttachments, text, ssml, inputHint);
@@ -409,18 +379,12 @@ public class MessageFactoryTests {
         InputHints inputHint = InputHints.EXPECTING_INPUT;
 
         String attachmentName1 = UUID.randomUUID().toString();
-        Attachment attachment1 = new Attachment() {
-            {
-                setName(attachmentName1);
-            }
-        };
+        Attachment attachment1 = new Attachment();
+        attachment1.setName(attachmentName1);
 
         String attachmentName2 = UUID.randomUUID().toString();
-        Attachment attachment2 = new Attachment() {
-            {
-                setName(attachmentName2);
-            }
-        };
+        Attachment attachment2 = new Attachment();
+        attachment2.setName(attachmentName2);
 
         Set<Attachment> multipleAttachments = new HashSet<>(
             Arrays.asList(attachment1, attachment2)
@@ -481,14 +445,12 @@ public class MessageFactoryTests {
 
         BotCallbackHandler replyWithimBackBack = turnContext -> {
             if (StringUtils.equals(turnContext.getActivity().getText(), "test")) {
+                CardAction card = new CardAction();
+                card.setType(ActionTypes.IM_BACK);
+                card.setText("red");
+                card.setTitle("redTitle");
                 Activity activity = MessageFactory.suggestedCardActions(
-                    Collections.singletonList(new CardAction() {
-                        {
-                            setType(ActionTypes.IM_BACK);
-                            setText("red");
-                            setTitle("redTitle");
-                        }
-                    }),
+                    Collections.singletonList(card),
                     "Select color"
                 );
 
@@ -534,14 +496,12 @@ public class MessageFactoryTests {
 
         BotCallbackHandler replyWithimBackBack = turnContext -> {
             if (StringUtils.equals(turnContext.getActivity().getText(), "test")) {
+                CardAction card = new CardAction();
+                card.setType(ActionTypes.IM_BACK);
+                card.setText("red");
+                card.setTitle("redTitle");
                 Activity activity = MessageFactory.suggestedCardActions(
-                    Collections.singletonList(new CardAction() {
-                        {
-                            setType(ActionTypes.IM_BACK);
-                            setText("red");
-                            setTitle("redTitle");
-                        }
-                    }),
+                    Collections.singletonList(card),
                     null
                 );
 

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/StorageBaseTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/StorageBaseTests.java
@@ -19,12 +19,9 @@ public class StorageBaseTests {
     }
 
     protected void createObjectTest(Storage storage) {
-        Map<String, Object> storeItems = new HashMap<String, Object>() {
-            {
-                put("createPoco", new PocoItem("1"));
-                put("createPocoStoreItem", new PocoStoreItem("1"));
-            }
-        };
+        Map<String, Object> storeItems = new HashMap<String, Object>();
+        storeItems.put("createPoco", new PocoItem("1"));
+        storeItems.put("createPocoStoreItem", new PocoStoreItem("1"));
 
         storage.write(storeItems).join();
 
@@ -55,12 +52,8 @@ public class StorageBaseTests {
     protected void handleCrazyKeys(Storage storage) {
         String key = "!@#$%^&*()~/\\><,.?';\"`~";
         PocoStoreItem storeItem = new PocoStoreItem("1");
-        Map<String, Object> dict = new HashMap<String, Object>() {
-            {
-                put(key, storeItem);
-            }
-        };
-
+        Map<String, Object> dict = new HashMap<String, Object>();
+        dict.put(key, storeItem);
         storage.write(dict).join();
         Map<String, Object> storeItems = storage.read(new String[] { key }).join();
 
@@ -71,12 +64,9 @@ public class StorageBaseTests {
     }
 
     protected void updateObjectTest(Storage storage) {
-        Map<String, Object> dict = new HashMap<String, Object>() {
-            {
-                put("pocoItem", new PocoItem("1", 1));
-                put("pocoStoreItem", new PocoStoreItem("1", 1));
-            }
-        };
+        Map<String, Object> dict = new HashMap<String, Object>();
+        dict.put("pocoItem", new PocoItem("1", 1));
+        dict.put("pocoStoreItem", new PocoStoreItem("1", 1));
 
         storage.write(dict).join();
         Map<String, Object> loadedStoreItems = storage.read(
@@ -127,24 +117,18 @@ public class StorageBaseTests {
 
         try {
             updatePocoItem.setCount(123);
-
-            storage.write(new HashMap<String, Object>() {
-                {
-                    put("pocoItem", updatePocoItem);
-                }
-            }).join();
+            HashMap<String, Object> pocoList = new HashMap<String, Object>();
+            pocoList.put("pocoItem", updatePocoItem);
+            storage.write(pocoList).join();
         } catch (Throwable t) {
             Assert.fail("Should not throw exception on write with pocoItem");
         }
 
         try {
             updatePocoStoreItem.setCount(123);
-
-            storage.write(new HashMap<String, Object>() {
-                {
-                    put("pocoStoreItem", updatePocoStoreItem);
-                }
-            }).join();
+            HashMap<String, Object> pocoList = new HashMap<String, Object>();
+            pocoList.put("pocoStoreItem", updatePocoStoreItem);
+            storage.write(pocoList).join();
 
             Assert.fail(
                 "Should have thrown exception on write with store item because of old etag"
@@ -169,13 +153,10 @@ public class StorageBaseTests {
         reloadedPocoItem2.setCount(100);
         reloadedPocoStoreItem2.setCount(100);
         reloadedPocoStoreItem2.setETag("*");
-
-        storage.write(new HashMap<String, Object>() {
-            {
-                put("pocoItem", reloadedPocoItem2);
-                put("pocoStoreItem", reloadedPocoStoreItem2);
-            }
-        }).join();
+        HashMap<String, Object> pocoList = new HashMap<String, Object>();
+        pocoList.put("pocoItem", reloadedPocoItem2);
+        pocoList.put("pocoStoreItem", reloadedPocoStoreItem2);
+        storage.write(pocoList).join();
 
         Map<String, Object> reloadedStoreItems3 = storage.read(
             new String[] { "pocoItem", "pocoStoreItem" }
@@ -195,11 +176,9 @@ public class StorageBaseTests {
 
             reloadedStoreItem4.setETag("");
 
-            storage.write(new HashMap<String, Object>() {
-                {
-                    put("pocoStoreItem", reloadedStoreItem4);
-                }
-            }).join();
+            HashMap<String, Object> pocoList2 = new HashMap<String, Object>();
+            pocoList2.put("pocoStoreItem", reloadedStoreItem4);
+            storage.write(pocoList2).join();
 
             Assert.fail(
                 "Should have thrown exception on write with storeitem because of empty etag"
@@ -216,11 +195,8 @@ public class StorageBaseTests {
     }
 
     protected void deleteObjectTest(Storage storage) {
-        Map<String, Object> dict = new HashMap<String, Object>() {
-            {
-                put("delete1", new PocoStoreItem("1", 1));
-            }
-        };
+        Map<String, Object> dict = new HashMap<String, Object>();
+        dict.put("delete1", new PocoStoreItem("1", 1));
 
         storage.write(dict).join();
 

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TelemetryMiddlewareTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TelemetryMiddlewareTests.java
@@ -54,12 +54,9 @@ public class TelemetryMiddlewareTests {
         String[] conversationId = new String[] { null };
         new TestFlow(adapter, (turnContext -> {
             conversationId[0] = turnContext.getActivity().getConversation().getId();
-            turnContext.sendActivity(new Activity() {
-                {
-                    setType(ActivityTypes.TYPING);
-                    setRelatesTo(turnContext.getActivity().getRelatesTo());
-                }
-            }).join();
+            Activity activity = new Activity(ActivityTypes.TYPING);
+            activity.setRelatesTo(turnContext.getActivity().getRelatesTo());
+            turnContext.sendActivity(activity).join();
             turnContext.sendActivity("echo:" + turnContext.getActivity().getText()).join();
             return CompletableFuture.completedFuture(null);
         })).send("foo").assertReply(activity -> {
@@ -127,12 +124,9 @@ public class TelemetryMiddlewareTests {
         String[] conversationId = new String[] { null };
         new TestFlow(adapter, (turnContext -> {
             conversationId[0] = turnContext.getActivity().getConversation().getId();
-            turnContext.sendActivity(new Activity() {
-                {
-                    setType(ActivityTypes.TYPING);
-                    setRelatesTo(turnContext.getActivity().getRelatesTo());
-                }
-            }).join();
+            Activity activity = new Activity(ActivityTypes.TYPING);
+            activity.setRelatesTo(turnContext.getActivity().getRelatesTo());
+            turnContext.sendActivity(activity).join();
             turnContext.sendActivity("echo:" + turnContext.getActivity().getText()).join();
             return CompletableFuture.completedFuture(null);
         })).send("foo").assertReply(activity -> {
@@ -278,12 +272,9 @@ public class TelemetryMiddlewareTests {
         String[] conversationId = new String[] { null };
         new TestFlow(adapter, (turnContext -> {
             conversationId[0] = turnContext.getActivity().getConversation().getId();
-            turnContext.sendActivity(new Activity() {
-                {
-                    setType(ActivityTypes.TYPING);
-                    setRelatesTo(turnContext.getActivity().getRelatesTo());
-                }
-            }).join();
+            Activity activity = new Activity(ActivityTypes.TYPING);
+            activity.setRelatesTo(turnContext.getActivity().getRelatesTo());
+            turnContext.sendActivity(activity).join();
             turnContext.sendActivity("echo:" + turnContext.getActivity().getText()).join();
             return CompletableFuture.completedFuture(null);
         })).send("foo").assertReply(activity -> {
@@ -349,12 +340,9 @@ public class TelemetryMiddlewareTests {
         String[] conversationId = new String[] { null };
         new TestFlow(adapter, (turnContext -> {
             conversationId[0] = turnContext.getActivity().getConversation().getId();
-            turnContext.sendActivity(new Activity() {
-                {
-                    setType(ActivityTypes.TYPING);
-                    setRelatesTo(turnContext.getActivity().getRelatesTo());
-                }
-            }).join();
+            Activity activity = new Activity(ActivityTypes.TYPING);
+            activity.setRelatesTo(turnContext.getActivity().getRelatesTo());
+            turnContext.sendActivity(activity).join();
             turnContext.sendActivity("echo:" + turnContext.getActivity().getText()).join();
             return CompletableFuture.completedFuture(null);
         })).send("foo").assertReply(activity -> {
@@ -547,25 +535,23 @@ public class TelemetryMiddlewareTests {
             new TelemetryLoggerMiddleware(mockTelemetryClient, true)
         );
 
-        TeamInfo teamInfo = new TeamInfo() {{
-            setId("teamId");
-            setName("teamName");
-        }};
+        TeamInfo teamInfo = new TeamInfo();
+        teamInfo.setId("teamId");
+        teamInfo.setName("teamName");
 
-        TeamsChannelData channelData = new TeamsChannelData() {{
-           setTeam(teamInfo);
-           setTenant(new TenantInfo() {{
-               setId("tenantId");
-           }});
-        }};
+        TeamsChannelData channelData = new TeamsChannelData();
+        channelData.setTeam(teamInfo);
+        TenantInfo tenant = new TenantInfo();
+        tenant.setId("tenantId");
+        channelData.setTenant(tenant);
 
         Activity activity = MessageFactory.text("test");
         activity.setChannelData(channelData);
-        activity.setFrom(new ChannelAccount() {{
-            setId("userId");
-            setName("userName");
-            setAadObjectId("aadId");
-        }});
+        ChannelAccount from = new ChannelAccount();
+        from.setId("userId");
+        from.setName("userName");
+        from.setAadObjectId("aadId");
+        activity.setFrom(from);
 
         new TestFlow(adapter).send(activity).startTest().join();
 
@@ -593,12 +579,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onReceiveActivity(Activity activity) {
-            Map<String, String> customProperties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> customProperties = new HashMap<String, String>();
+            customProperties.put("foo", "bar");
+            customProperties.put("ImportantProperty", "ImportantValue");
 
             getTelemetryClient().trackEvent(
                 TelemetryLoggerConstants.BOTMSGRECEIVEEVENT,
@@ -622,12 +605,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onSendActivity(Activity activity) {
-            Map<String, String> customProperties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> customProperties = new HashMap<String, String>();
+            customProperties.put("foo", "bar");
+            customProperties.put("ImportantProperty", "ImportantValue");
 
             getTelemetryClient().trackEvent(
                 TelemetryLoggerConstants.BOTMSGSENDEVENT,
@@ -651,12 +631,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onUpdateActivity(Activity activity) {
-            Map<String, String> properties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> properties = new HashMap<String, String>();
+            properties.put("foo", "bar");
+            properties.put("ImportantProperty", "ImportantValue");
 
             getTelemetryClient().trackEvent(TelemetryLoggerConstants.BOTMSGUPDATEEVENT, properties);
             return CompletableFuture.completedFuture(null);
@@ -664,12 +641,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onDeleteActivity(Activity activity) {
-            Map<String, String> properties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> properties = new HashMap<String, String>();
+            properties.put("foo", "bar");
+            properties.put("ImportantProperty", "ImportantValue");
 
             getTelemetryClient().trackEvent(TelemetryLoggerConstants.BOTMSGDELETEEVENT, properties);
             return CompletableFuture.completedFuture(null);
@@ -686,12 +660,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onReceiveActivity(Activity activity) {
-            Map<String, String> customProperties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> customProperties = new HashMap<String, String>();
+            customProperties.put("foo", "bar");
+            customProperties.put("ImportantProperty", "ImportantValue");
 
             return fillReceiveEventProperties(activity, customProperties).thenApply(
                 allProperties -> {
@@ -706,12 +677,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onSendActivity(Activity activity) {
-            Map<String, String> customProperties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> customProperties = new HashMap<String, String>();
+            customProperties.put("foo", "bar");
+            customProperties.put("ImportantProperty", "ImportantValue");
 
             return fillSendEventProperties(activity, customProperties).thenApply(allProperties -> {
                 getTelemetryClient().trackEvent(
@@ -724,12 +692,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onUpdateActivity(Activity activity) {
-            Map<String, String> customProperties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> customProperties = new HashMap<String, String>();
+            customProperties.put("foo", "bar");
+            customProperties.put("ImportantProperty", "ImportantValue");
 
             return fillUpdateEventProperties(activity, customProperties).thenApply(
                 allProperties -> {
@@ -744,12 +709,9 @@ public class TelemetryMiddlewareTests {
 
         @Override
         protected CompletableFuture<Void> onDeleteActivity(Activity activity) {
-            Map<String, String> customProperties = new HashMap<String, String>() {
-                {
-                    put("foo", "bar");
-                    put("ImportantProperty", "ImportantValue");
-                }
-            };
+            Map<String, String> customProperties = new HashMap<String, String>();
+            customProperties.put("foo", "bar");
+            customProperties.put("ImportantProperty", "ImportantValue");
 
             return fillDeleteEventProperties(activity, customProperties).thenApply(
                 allProperties -> {

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TestAdapterTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TestAdapterTests.java
@@ -116,16 +116,13 @@ public class TestAdapterTests {
     @Test
     public void TestAdapter_Say() {
         TestAdapter adapter = new TestAdapter();
+        Activity messageActivity = new Activity(ActivityTypes.MESSAGE);
+        messageActivity.setText("echo:foo");
         new TestFlow(adapter, this::myBotLogic).test(
             "foo",
             "echo:foo",
             "say with string works"
-        ).test("foo", new Activity() {
-            {
-                setType(ActivityTypes.MESSAGE);
-                setText("echo:foo");
-            }
-        }, "say with activity works").test("foo", activity -> {
+        ).test("foo", messageActivity, "say with activity works").test("foo", activity -> {
             Assert.assertEquals("echo:foo", activity.getText());
         }, "say with validator works").startTest().join();
     }
@@ -133,15 +130,12 @@ public class TestAdapterTests {
     @Test
     public void TestAdapter_SendReply() {
         TestAdapter adapter = new TestAdapter();
+        Activity messageActivity = new Activity(ActivityTypes.MESSAGE);
+        messageActivity.setText("echo:foo");
         new TestFlow(adapter, this::myBotLogic).send("foo").assertReply(
             "echo:foo",
             "say with string works"
-        ).send("foo").assertReply(new Activity() {
-            {
-                setType(ActivityTypes.MESSAGE);
-                setText("echo:foo");
-            }
-        }, "say with activity works").send("foo").assertReply(activity -> {
+        ).send("foo").assertReply(messageActivity, "say with activity works").send("foo").assertReply(activity -> {
             Assert.assertEquals("echo:foo", activity.getText());
         }, "say with validator works").startTest().join();
     }
@@ -186,16 +180,11 @@ public class TestAdapterTests {
     @Test
     public void TestAdapter_GetUserTokenAsyncReturnsNull() {
         TestAdapter adapter = new TestAdapter();
-        Activity activity = new Activity() {
-            {
-                setChannelId("directline");
-                setFrom(new ChannelAccount() {
-                    {
-                        setId("testuser");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId("directline");
+        ChannelAccount from = new ChannelAccount();
+        from.setId("testuser");
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         TokenResponse token = adapter.getUserToken(turnContext, "myconnection", null).join();
@@ -205,16 +194,11 @@ public class TestAdapterTests {
     @Test
     public void TestAdapter_GetUserTokenAsyncReturnsNullWithCode() {
         TestAdapter adapter = new TestAdapter();
-        Activity activity = new Activity() {
-            {
-                setChannelId("directline");
-                setFrom(new ChannelAccount() {
-                    {
-                        setId("testuser");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId("directline");
+        ChannelAccount from = new ChannelAccount();
+        from.setId("testuser");
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         TokenResponse token = adapter.getUserToken(turnContext, "myconnection", "abc123").join();
@@ -228,16 +212,11 @@ public class TestAdapterTests {
         String channelId = "directline";
         String userId = "testUser";
         String token = "abc123";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         adapter.addUserToken(connectionName, channelId, userId, token, null);
@@ -260,16 +239,11 @@ public class TestAdapterTests {
         String userId = "testUser";
         String token = "abc123";
         String magicCode = "888999";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         adapter.addUserToken(connectionName, channelId, userId, token, magicCode);
@@ -293,16 +267,11 @@ public class TestAdapterTests {
         String connectionName = "myConnection";
         String channelId = "directline";
         String userId = "testUser";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         String link = adapter.getOAuthSignInLink(turnContext, connectionName, userId, null).join();
@@ -316,16 +285,11 @@ public class TestAdapterTests {
         String connectionName = "myConnection";
         String channelId = "directline";
         String userId = "testUser";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         String link = adapter.getOAuthSignInLink(turnContext, connectionName).join();
@@ -339,16 +303,11 @@ public class TestAdapterTests {
         String connectionName = "myConnection";
         String channelId = "directline";
         String userId = "testUser";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         adapter.signOutUser(turnContext, null, null).join();
@@ -364,16 +323,11 @@ public class TestAdapterTests {
         String channelId = "directline";
         String userId = "testUser";
         String token = "abc123";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         adapter.addUserToken(connectionName, channelId, userId, token, null);
@@ -399,16 +353,11 @@ public class TestAdapterTests {
         String channelId = "directline";
         String userId = "testUser";
         String token = "abc123";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+                activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         adapter.addUserToken("ABC", channelId, userId, token, null);
@@ -438,16 +387,11 @@ public class TestAdapterTests {
         String channelId = "directline";
         String userId = "testUser";
         String token = "abc123";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         adapter.addUserToken("ABC", channelId, userId, token, null);
@@ -465,16 +409,11 @@ public class TestAdapterTests {
         String channelId = "directline";
         String userId = "testUser";
         String token = "abc123";
-        Activity activity = new Activity() {
-            {
-                setChannelId(channelId);
-                setFrom(new ChannelAccount() {
-                    {
-                        setId(userId);
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId(channelId);
+        ChannelAccount from = new ChannelAccount();
+        from.setId(userId);
+        activity.setFrom(from);
         TurnContext turnContext = new TurnContextImpl(adapter, activity);
 
         adapter.addUserToken("ABC", channelId, userId, token, null);

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TestMessage.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TestMessage.java
@@ -14,22 +14,17 @@ public class TestMessage {
     }
 
     public static Activity Message(String id) {
-        Activity a = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setId(id);
-                setText("test");
-                setFrom(new ChannelAccount("user", "User Name"));
-                setRecipient(new ChannelAccount("bot", "Bot Name"));
-                setConversation(new ConversationAccount() {
-                    {
-                        setId("convo");
-                        setName("Convo Name");
-                    }
-                });
-                setChannelId("UnitTest");
-                setServiceUrl("https://example.org");
-            }
-        };
+        Activity a = new Activity(ActivityTypes.MESSAGE);
+        a.setId(id);
+        a.setText("test");
+        a.setFrom(new ChannelAccount("user", "User Name"));
+        a.setRecipient(new ChannelAccount("bot", "Bot Name"));
+        ConversationAccount conversationAccount = new ConversationAccount();
+        conversationAccount.setId("convo");
+        conversationAccount.setName("Convo Name");
+        a.setConversation(conversationAccount);
+        a.setChannelId("UnitTest");
+        a.setServiceUrl("https://example.org");
         return a;
     }
 }

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TestUtilities.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TestUtilities.java
@@ -12,22 +12,14 @@ import com.microsoft.bot.schema.ConversationAccount;
 public final class TestUtilities {
     public static TurnContext createEmptyContext() {
         TestAdapter adapter = new TestAdapter();
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.MESSAGE);
-                setChannelId("EmptyContext");
-                setConversation(new ConversationAccount() {
-                    {
-                        setId("test");
-                    }
-                });
-                setFrom(new ChannelAccount() {
-                    {
-                        setId("empty@empty.context.org");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setChannelId("EmptyContext");
+        ConversationAccount conversation = new ConversationAccount();
+        conversation.setId("test");
+        activity.setConversation(conversation);
+        ChannelAccount from = new ChannelAccount();
+        from.setId("empty@empty.context.org");
+        activity.setFrom(from);
 
         return new TurnContextImpl(adapter, activity);
     }

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TranscriptMiddlewareTest.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TranscriptMiddlewareTest.java
@@ -32,11 +32,8 @@ public class TranscriptMiddlewareTest {
                 return null;
             }
         };
-        Activity typingActivity = new Activity(ActivityTypes.TYPING) {
-            {
-                setRelatesTo(context.getActivity().getRelatesTo());
-            }
-        };
+        Activity typingActivity = new Activity(ActivityTypes.TYPING);
+        typingActivity.setRelatesTo(context.getActivity().getRelatesTo());
 
         try {
             context.sendActivity(typingActivity).join();
@@ -58,11 +55,8 @@ public class TranscriptMiddlewareTest {
         new TestFlow(adapter, (context) -> {
             delay(500);
             conversationId[0] = context.getActivity().getConversation().getId();
-            Activity typingActivity = new Activity(ActivityTypes.TYPING) {
-                {
-                    setRelatesTo(context.getActivity().getRelatesTo());
-                }
-            };
+            Activity typingActivity = new Activity(ActivityTypes.TYPING);
+            typingActivity.setRelatesTo(context.getActivity().getRelatesTo());
 
             context.sendActivity(typingActivity).join();
 

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TurnContextTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TurnContextTests.java
@@ -319,11 +319,9 @@ public class TurnContextTests {
             foundActivity[0] = true;
         });
 
-        TurnContext c = new TurnContextImpl(a, new Activity(ActivityTypes.MESSAGE) {
-            {
-                setConversation(new ConversationAccount(CONVERSATION_ID));
-            }
-        });
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setConversation(new ConversationAccount(CONVERSATION_ID));
+        TurnContext c = new TurnContextImpl(a, activity);
 
         Activity message = MessageFactory.text("test text");
         message.setId(ACTIVITY_ID);
@@ -435,11 +433,8 @@ public class TurnContextTests {
 
         TurnContext c = new TurnContextImpl(a, TestMessage.Message());
 
-        ConversationReference reference = new ConversationReference() {
-            {
-                setActivityId("12345");
-            }
-        };
+        ConversationReference reference = new ConversationReference();
+        reference.setActivityId("12345");
 
         c.deleteActivity(reference).join();
         Assert.assertTrue(activityDeleted[0]);

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/adapters/TestAdapter.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/adapters/TestAdapter.java
@@ -97,25 +97,19 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
         ConversationReference conversationReference = new ConversationReference();
         conversationReference.setChannelId(channelId);
         conversationReference.setServiceUrl("https://test.com");
-        conversationReference.setUser(new ChannelAccount() {
-            {
-                setId("user1");
-                setName("User1");
-            }
-        });
-        conversationReference.setBot(new ChannelAccount() {
-            {
-                setId("bot");
-                setName("Bot");
-            }
-        });
-        conversationReference.setConversation(new ConversationAccount() {
-            {
-                setIsGroup(false);
-                setConversationType("convo1");
-                setId("Conversation1");
-            }
-        });
+        ChannelAccount userAccount = new ChannelAccount();
+        userAccount.setId("user1");
+        userAccount.setName("User1");
+        conversationReference.setUser(userAccount);
+        ChannelAccount botAccount = new ChannelAccount();
+        botAccount.setId("bot");
+        botAccount.setName("Bot");
+        conversationReference.setBot(botAccount);
+        ConversationAccount conversation = new ConversationAccount();
+        conversation.setIsGroup(false);
+        conversation.setConversationType("convo1");
+        conversation.setId("Conversation1");
+        conversationReference.setConversation(conversation);
         conversationReference.setLocale(this.getLocale());
 
         setConversationReference(conversationReference);
@@ -128,25 +122,19 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
             ConversationReference conversationReference = new ConversationReference();
             conversationReference.setChannelId(Channels.TEST);
             conversationReference.setServiceUrl("https://test.com");
-            conversationReference.setUser(new ChannelAccount() {
-                {
-                    setId("user1");
-                    setName("User1");
-                }
-            });
-            conversationReference.setBot(new ChannelAccount() {
-                {
-                    setId("bot");
-                    setName("Bot");
-                }
-            });
-            conversationReference.setConversation(new ConversationAccount() {
-                {
-                    setIsGroup(false);
-                    setConversationType("convo1");
-                    setId("Conversation1");
-                }
-            });
+            ChannelAccount userAccount = new ChannelAccount();
+            userAccount.setId("user1");
+            userAccount.setName("User1");
+            conversationReference.setUser(userAccount);
+            ChannelAccount botAccount = new ChannelAccount();
+            botAccount.setId("bot");
+            botAccount.setName("Bot");
+            conversationReference.setBot(botAccount);
+            ConversationAccount conversation = new ConversationAccount();
+            conversation.setIsGroup(false);
+            conversation.setConversationType("convo1");
+            conversation.setId("Conversation1");
+            conversationReference.setConversation(conversation);
             conversationReference.setLocale(this.getLocale());
             setConversationReference(conversationReference);
         }
@@ -348,17 +336,14 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
     public Activity makeActivity(String withText) {
         Integer next = nextId++;
         String locale = !getLocale().isEmpty() ? getLocale() : "en-us";
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setLocale(locale);
-                setFrom(conversationReference().getUser());
-                setRecipient(conversationReference().getBot());
-                setConversation(conversationReference().getConversation());
-                setServiceUrl(conversationReference().getServiceUrl());
-                setId(next.toString());
-                setText(withText);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setLocale(locale);
+        activity.setFrom(conversationReference().getUser());
+        activity.setRecipient(conversationReference().getBot());
+        activity.setConversation(conversationReference().getConversation());
+        activity.setServiceUrl(conversationReference().getServiceUrl());
+        activity.setId(next.toString());
+        activity.setText(withText);
         activity.setLocale(getLocale() != null ? getLocale() : "en-us");
 
         return activity;
@@ -384,13 +369,11 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
         if (withMagicCode == null) {
             userTokens.put(userKey, token);
         } else {
-            magicCodes.add(new TokenMagicCode() {
-                {
-                    key = userKey;
-                    magicCode = withMagicCode;
-                    userToken = token;
-                }
-            });
+            TokenMagicCode tokenMagicCode = new TokenMagicCode();
+            tokenMagicCode.key = userKey;
+            tokenMagicCode.magicCode = withMagicCode;
+            tokenMagicCode.userToken = token;
+            magicCodes.add(tokenMagicCode);
         }
     }
 
@@ -484,12 +467,10 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
                 }
 
                 if (userTokens.containsKey(key)) {
-                    return CompletableFuture.completedFuture(new TokenResponse() {
-                        {
-                            setConnectionName(connectionName);
-                            setToken(userTokens.get(key));
-                        }
-                    });
+                    TokenResponse tokenResponse = new TokenResponse();
+                    tokenResponse.setConnectionName(connectionName);
+                    tokenResponse.setToken(userTokens.get(key));
+                    return CompletableFuture.completedFuture(tokenResponse);
                 }
 
                 return CompletableFuture.completedFuture(null);
@@ -564,12 +545,12 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
                 .filter(x -> StringUtils.equals(x.channelId, turnContext.getActivity().getChannelId())
                         && StringUtils.equals(x.userId, turnContext.getActivity().getFrom().getId())
                         && (includeFilter == null || Arrays.binarySearch(filter, x.connectionName) != -1))
-                .map(r -> new TokenStatus() {
-                    {
-                        setConnectionName(r.connectionName);
-                        setHasToken(true);
-                        setServiceProviderDisplayName(r.connectionName);
-                    }
+                .map(r -> {
+                    TokenStatus tokenStatus = new TokenStatus();
+                    tokenStatus.setConnectionName(r.connectionName);
+                    tokenStatus.setHasToken(true);
+                    tokenStatus.setServiceProviderDisplayName(r.connectionName);
+                    return tokenStatus;
                 }).collect(Collectors.toList());
 
         if (records.size() > 0) {
@@ -659,13 +640,11 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
                         new RuntimeException("Exception occurred during exchanging tokens")
                     );
                 }
-                return CompletableFuture.completedFuture(new TokenResponse() {
-                    {
-                        setChannelId(key.getChannelId());
-                        setConnectionName(key.getConnectionName());
-                        setToken(token);
-                    }
-                });
+                TokenResponse tokenResponse = new TokenResponse();
+                tokenResponse.setChannelId(key.getChannelId());
+                tokenResponse.setConnectionName(key.getConnectionName());
+                tokenResponse.setToken(token);
+                return CompletableFuture.completedFuture(tokenResponse);
             } else {
                 return CompletableFuture.completedFuture(null);
             }

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerBadRequestTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerBadRequestTests.java
@@ -21,23 +21,16 @@ import java.util.concurrent.atomic.AtomicReference;
 public class TeamsActivityHandlerBadRequestTests {
     @Test
     public void TestFileConsentBadAction() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("fileConsent/invoke");
-                setValue(new FileConsentCardResponse() {
-                    {
-                        setAction("this.is.a.bad.action");
-                        setUploadInfo(new FileUploadInfo() {
-                            {
-                                setUniqueId("uniqueId");
-                                setFileType("fileType");
-                                setUploadUrl("uploadUrl");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("fileConsent/invoke");
+        FileUploadInfo fileInfo = new FileUploadInfo();
+        fileInfo.setUniqueId("uniqueId");
+        fileInfo.setFileType("fileType");
+        fileInfo.setUploadUrl("uploadUrl");
+        FileConsentCardResponse fileConsentCard = new FileConsentCardResponse();
+        fileConsentCard.setAction("this.is.a.bad.action");
+        fileConsentCard.setUploadInfo(fileInfo);
+        activity.setValue(fileConsentCard);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -60,16 +53,11 @@ public class TeamsActivityHandlerBadRequestTests {
 
     @Test
     public void TestMessagingExtensionSubmitActionPreviewBadAction() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setBotMessagePreviewAction("this.is.a.bad.action");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setBotMessagePreviewAction("this.is.a.bad.action");
+        activity.setValue(action);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerHidingTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerHidingTests.java
@@ -42,17 +42,11 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberAdded1() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("b"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("b"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -65,18 +59,12 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberAdded2() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("b"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("b"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -90,19 +78,13 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberAdded3() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("b"));
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("b"));
+        members.add(new ChannelAccount("c"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -116,17 +98,11 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberRemoved1() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -139,18 +115,12 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberRemoved2() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -164,19 +134,13 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberRemoved3() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                        add(new ChannelAccount("b"));
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        members.add(new ChannelAccount("b"));
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -190,17 +154,11 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberAddedJustTheBot() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("b"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("b"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -213,17 +171,11 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestMemberRemovedJustTheBot() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.CONVERSATION_UPDATE);
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("c"));
-                    }
-                });
-                setRecipient(new ChannelAccount("c"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("c"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("c"));
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -241,21 +193,13 @@ public class TeamsActivityHandlerHidingTests {
         // sends separate activities each with a single add and a single remove.
 
         // Arrange
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.MESSAGE_REACTION);
-                setReactionsAdded(new ArrayList<MessageReaction>() {
-                    {
-                        add(new MessageReaction("sad"));
-                    }
-                });
-                setReactionsRemoved(new ArrayList<MessageReaction>() {
-                    {
-                        add(new MessageReaction("angry"));
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE_REACTION);
+        ArrayList<MessageReaction> reactionsAdded = new ArrayList<MessageReaction>();
+        reactionsAdded.add(new MessageReaction("sad"));
+        activity.setReactionsAdded(reactionsAdded);
+        ArrayList<MessageReaction> reactionsRemoved = new ArrayList<MessageReaction>();
+        reactionsRemoved.add(new MessageReaction("angry"));
+        activity.setReactionsRemoved(reactionsRemoved);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -270,12 +214,8 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestTokenResponseEventAsync() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.EVENT);
-                setName("tokens/response");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.EVENT);
+        activity.setName("tokens/response");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -289,12 +229,8 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestEventAsync() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.EVENT);
-                setName("some.random.event");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.EVENT);
+        activity.setName("some.random.event");
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -308,11 +244,7 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestEventNullNameAsync() {
-        Activity activity = new Activity() {
-            {
-                setType(ActivityTypes.EVENT);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.EVENT);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -326,12 +258,7 @@ public class TeamsActivityHandlerHidingTests {
 
     @Test
     public void TestUnrecognizedActivityType() {
-        Activity activity = new Activity() {
-            {
-                setType("shall.not.pass");
-            }
-        };
-
+        Activity activity = new Activity("shall.not.pass");
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
         TestActivityHandler bot = new TestActivityHandler();

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerNotImplementedTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerNotImplementedTests.java
@@ -30,317 +30,220 @@ import java.util.concurrent.atomic.AtomicReference;
 public class TeamsActivityHandlerNotImplementedTests {
     @Test
     public void TestInvoke() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("gibberish");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("gibberish");
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestFileConsentAccept() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("fileConsent/invoke");
-                setValue(new FileConsentCardResponse() {
-                    {
-                        setAction("accept");
-                        setUploadInfo(new FileUploadInfo() {
-                            {
-                                setUniqueId("uniqueId");
-                                setFileType("fileType");
-                                setUploadUrl("uploadUrl");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("fileConsent/invoke");
+        FileUploadInfo fileInfo = new FileUploadInfo();
+        fileInfo.setUniqueId("uniqueId");
+        fileInfo.setFileType("fileType");
+        fileInfo.setUploadUrl("uploadUrl");
+        FileConsentCardResponse response = new FileConsentCardResponse();
+        response.setAction("accept");
+        response.setUploadInfo(fileInfo);
+        activity.setValue(response);
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestFileConsentDecline() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("fileConsent/invoke");
-                setValue(new FileConsentCardResponse() {
-                    {
-                        setAction("decline");
-                        setUploadInfo(new FileUploadInfo() {
-                            {
-                                setUniqueId("uniqueId");
-                                setFileType("fileType");
-                                setUploadUrl("uploadUrl");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("fileConsent/invoke");
+        FileUploadInfo fileInfo = new FileUploadInfo();
+        fileInfo.setUniqueId("uniqueId");
+        fileInfo.setFileType("fileType");
+        fileInfo.setUploadUrl("uploadUrl");
+        FileConsentCardResponse response = new FileConsentCardResponse();
+        response.setAction("decline");
+        response.setUploadInfo(fileInfo);
+        activity.setValue(response);
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestActionableMessageExecuteAction() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("actionableMessage/executeAction");
-                setValue(new O365ConnectorCardActionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("actionableMessage/executeAction");
+        activity.setValue(new O365ConnectorCardActionQuery());
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestComposeExtensionQueryLink() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/queryLink");
-                setValue(new AppBasedLinkQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/queryLink");
+        activity.setValue(new AppBasedLinkQuery());
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestComposeExtensionQuery() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/query");
-                setValue(new MessagingExtensionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/query");
+        activity.setValue(new MessagingExtensionQuery());
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestMessagingExtensionSelectItem() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/selectItem");
-                setValue(new O365ConnectorCardActionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/selectItem");
+        activity.setValue(new O365ConnectorCardActionQuery());
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestMessagingExtensionSubmitAction() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        activity.setValue(new MessagingExtensionQuery());
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestMessagingExtensionSubmitActionPreviewActionEdit() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setBotMessagePreviewAction("edit");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setBotMessagePreviewAction("edit");
+        activity.setValue(action);
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestMessagingExtensionSubmitActionPreviewActionSend() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setBotMessagePreviewAction("send");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setBotMessagePreviewAction("send");
+        activity.setValue(action);
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestMessagingExtensionFetchTask() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/fetchTask");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setCommandId("testCommand");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/fetchTask");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setCommandId("testCommand");
+        activity.setValue(action);
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestMessagingExtensionConfigurationQuerySettingsUrl() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/querySettingsUrl");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/querySettingsUrl");
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestMessagingExtensionConfigurationSetting() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/setting");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/setting");
 
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestTaskModuleFetch() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("task/fetch");
-                setValue(new TaskModuleRequest() {
-                    {
-                        setData(new HashMap<String, Object>() {
-                            {
-                                put("key", "value");
-                                put("type", "task / fetch");
-                            }
-                        });
-                        setContext(new TaskModuleRequestContext() {
-                            {
-                                setTheme("default");
-                            }
-                        });
-                    }
-                });
-            }
-        };
-
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("task/fetch");
+        HashMap<String, Object> data = new HashMap<String, Object>();
+        data.put("key", "value");
+        data.put("type", "task / fetch");
+        TaskModuleRequestContext context = new TaskModuleRequestContext();
+        context.setTheme("default");
+        TaskModuleRequest request = new TaskModuleRequest();
+        request.setData(data);
+        request.setContext(context);
+        activity.setValue(request);
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestTaskModuleSubmit() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("task/submit");
-                setValue(new TaskModuleRequest() {
-                    {
-                        setData(new HashMap<String, Object>() {
-                            {
-                                put("key", "value");
-                                put("type", "task / fetch");
-                            }
-                        });
-                        setContext(new TaskModuleRequestContext() {
-                            {
-                                setTheme("default");
-                            }
-                        });
-                    }
-                });
-            }
-        };
-
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("task/submit");
+        HashMap<String, Object> data = new HashMap<String, Object>();
+        data.put("key", "value");
+        data.put("type", "task / fetch");
+        TaskModuleRequestContext context = new TaskModuleRequestContext();
+        context.setTheme("default");
+        TaskModuleRequest request = new TaskModuleRequest();
+        request.setData(data);
+        request.setContext(context);
+        activity.setValue(request);
         assertNotImplemented(activity);
     }
 
     @Test
     public void TestFileConsentAcceptImplemented() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("fileConsent/invoke");
-                setValue(new FileConsentCardResponse() {
-                    {
-                        setAction("accept");
-                        setUploadInfo(new FileUploadInfo() {
-                            {
-                                setUniqueId("uniqueId");
-                                setFileType("fileType");
-                                setUploadUrl("uploadUrl");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("fileConsent/invoke");
+        FileUploadInfo fileInfo = new FileUploadInfo();
+        fileInfo.setUniqueId("uniqueId");
+        fileInfo.setFileType("fileType");
+        fileInfo.setUploadUrl("uploadUrl");
+        FileConsentCardResponse response = new FileConsentCardResponse();
+        response.setAction("accept");
+        response.setUploadInfo(fileInfo);
+        activity.setValue(response);
 
         assertImplemented(activity, new TestActivityHandlerFileConsent());
     }
 
     @Test
     public void TestFileConsentDeclineImplemented() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("fileConsent/invoke");
-                setValue(new FileConsentCardResponse() {
-                    {
-                        setAction("decline");
-                        setUploadInfo(new FileUploadInfo() {
-                            {
-                                setUniqueId("uniqueId");
-                                setFileType("fileType");
-                                setUploadUrl("uploadUrl");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("fileConsent/invoke");
+        FileUploadInfo fileInfo = new FileUploadInfo();
+        fileInfo.setUniqueId("uniqueId");
+        fileInfo.setFileType("fileType");
+        fileInfo.setUploadUrl("uploadUrl");
+        FileConsentCardResponse response = new FileConsentCardResponse();
+        response.setAction("decline");
+        response.setUploadInfo(fileInfo);
+        activity.setValue(response);
 
         assertImplemented(activity, new TestActivityHandlerFileConsent());
     }
 
     @Test
     public void TestMessagingExtensionSubmitActionPreviewActionEditImplemented() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setBotMessagePreviewAction("edit");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setBotMessagePreviewAction("edit");
+        activity.setValue(action);
 
         assertImplemented(activity, new TestActivityHandlerPrevieAction());
     }
 
     @Test
     public void TestMessagingExtensionSubmitActionPreviewActionSendImplemented() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setBotMessagePreviewAction("send");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+                action.setBotMessagePreviewAction("send");
+        activity.setValue(action);
 
         assertImplemented(activity, new TestActivityHandlerPrevieAction());
     }

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java
@@ -59,23 +59,16 @@ public class TeamsActivityHandlerTests {
             MicrosoftAppCredentials.empty()
         );
 
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("botid-1"));
-                    }
-                });
-                setRecipient(new ChannelAccount("botid-1"));
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamMemberAdded");
-                        setTeam(new TeamInfo("team-id"));
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("botid-1"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("botid-1"));
+        TeamsChannelData channelData = new TeamsChannelData();
+        channelData.setEventType("teamMemberAdded");
+        channelData.setTeam(new TeamInfo("team-id"));
+        activity.setChannelData(channelData);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new SimpleAdapter(), activity);
         turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, connectorClient);
@@ -96,23 +89,16 @@ public class TeamsActivityHandlerTests {
             MicrosoftAppCredentials.empty()
         );
 
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("id-1"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamMemberAdded");
-                        setTeam(new TeamInfo("team-id"));
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("id-1"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
+        TeamsChannelData channelData = new TeamsChannelData();
+        channelData.setEventType("teamMemberAdded");
+        channelData.setTeam(new TeamInfo("team-id"));
+        activity.setChannelData(channelData);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new SimpleAdapter(), activity);
         turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, connectorClient);
@@ -133,18 +119,13 @@ public class TeamsActivityHandlerTests {
             MicrosoftAppCredentials.empty()
         );
 
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("id-1"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-                setConversation(new ConversationAccount("conversation-id"));
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("id-1"));
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
+        activity.setConversation(new ConversationAccount("conversation-id"));
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new SimpleAdapter(), activity);
         turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, connectorClient);
@@ -165,35 +146,26 @@ public class TeamsActivityHandlerTests {
             MicrosoftAppCredentials.empty()
         );
 
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setMembersAdded(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new TeamsChannelAccount() {
-                            {
-                                setId("id-1");
-                                setName("name-1");
-                                setAadObjectId("aadobject-1");
-                                setEmail("test@microsoft.com");
-                                setGivenName("given-1");
-                                setSurname("surname-1");
-                                setUserPrincipalName("t@microsoft.com");
-                                setTenantId("testTenantId");
-                                setUserRole("guest");
-                            }
-                        });
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamMemberAdded");
-                        setTeam(new TeamInfo("team-id"));
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        TeamsChannelAccount teams = new TeamsChannelAccount();
+        teams.setId("id-1");
+        teams.setName("name-1");
+        teams.setAadObjectId("aadobject-1");
+        teams.setEmail("test@microsoft.com");
+        teams.setGivenName("given-1");
+        teams.setSurname("surname-1");
+        teams.setUserPrincipalName("t@microsoft.com");
+        teams.setTenantId("testTenantId");
+        teams.setUserRole("guest");
+        members.add(teams);
+        activity.setMembersAdded(members);
+        activity.setRecipient(new ChannelAccount("b"));
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamMemberAdded");
+        data.setTeam(new TeamInfo("team-id"));
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         // serialize to json and back to verify we can get back to the
         // correct Activity. i.e., In this case, mainly the TeamsChannelAccount.
@@ -218,22 +190,15 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsMemberRemoved() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setMembersRemoved(new ArrayList<ChannelAccount>() {
-                    {
-                        add(new ChannelAccount("a"));
-                    }
-                });
-                setRecipient(new ChannelAccount("b"));
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamMemberRemoved");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        ArrayList<ChannelAccount> members = new ArrayList<ChannelAccount>();
+        members.add(new ChannelAccount("a"));
+        activity.setMembersRemoved(members);
+        activity.setRecipient(new ChannelAccount("b"));
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamMemberRemoved");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -247,16 +212,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsChannelCreated() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("channelCreated");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("channelCreated");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -270,16 +230,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsChannelDeleted() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("channelDeleted");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("channelDeleted");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -293,16 +248,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsChannelRenamed() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("channelRenamed");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("channelRenamed");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -316,16 +266,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsChannelRestored() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("channelRestored");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("channelRestored");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -339,16 +284,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsTeamRenamed() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamRenamed");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamRenamed");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -362,16 +302,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsTeamArchived() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamArchived");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamArchived");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -385,16 +320,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsTeamDeleted() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamDeleted");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamDeleted");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -408,16 +338,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsTeamHardDeleted() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamHardDeleted");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamHardDeleted");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -431,16 +356,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsTeamRestored() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamRestored");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamRestored");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -454,16 +374,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestConversationUpdateTeamsTeamUnarchived() {
-        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setEventType("teamUnarchived");
-                    }
-                });
-                setChannelId(Channels.MSTEAMS);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setEventType("teamUnarchived");
+        activity.setChannelData(data);
+        activity.setChannelId(Channels.MSTEAMS);
 
         TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
 
@@ -477,23 +392,16 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestFileConsentAccept() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("fileConsent/invoke");
-                setValue(new FileConsentCardResponse() {
-                    {
-                        setAction("accept");
-                        setUploadInfo(new FileUploadInfo() {
-                            {
-                                setUniqueId("uniqueId");
-                                setFileType("fileType");
-                                setUploadUrl("uploadUrl");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("fileConsent/invoke");
+        FileUploadInfo fileInfo = new FileUploadInfo();
+        fileInfo.setUniqueId("uniqueId");
+        fileInfo.setFileType("fileType");
+        fileInfo.setUploadUrl("uploadUrl");
+        FileConsentCardResponse response = new FileConsentCardResponse();
+        response.setAction("accept");
+        response.setUploadInfo(fileInfo);
+        activity.setValue(response);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -520,23 +428,16 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestFileConsentDecline() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("fileConsent/invoke");
-                setValue(new FileConsentCardResponse() {
-                    {
-                        setAction("decline");
-                        setUploadInfo(new FileUploadInfo() {
-                            {
-                                setUniqueId("uniqueId");
-                                setFileType("fileType");
-                                setUploadUrl("uploadUrl");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("fileConsent/invoke");
+        FileUploadInfo fileInfo = new FileUploadInfo();
+        fileInfo.setUniqueId("uniqueId");
+        fileInfo.setFileType("fileType");
+        fileInfo.setUploadUrl("uploadUrl");
+        FileConsentCardResponse response = new FileConsentCardResponse();
+        response.setAction("decline");
+        response.setUploadInfo(fileInfo);
+        activity.setValue(response);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -563,12 +464,9 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestActionableMessageExecuteAction() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("actionableMessage/executeAction");
-                setValue(new O365ConnectorCardActionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("actionableMessage/executeAction");
+        activity.setValue(new O365ConnectorCardActionQuery());
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -594,12 +492,9 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestComposeExtensionQueryLink() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/queryLink");
-                setValue(new AppBasedLinkQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/queryLink");
+        activity.setValue(new AppBasedLinkQuery());
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -625,12 +520,9 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestComposeExtensionQuery() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/query");
-                setValue(new MessagingExtensionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/query");
+        activity.setValue(new MessagingExtensionQuery());
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -656,12 +548,9 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestMessagingExtensionSelectItemAsync() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/selectItem");
-                setValue(new MessagingExtensionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/selectItem");
+        activity.setValue(new MessagingExtensionQuery());
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -687,12 +576,9 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestMessagingExtensionSubmitAction() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionQuery());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        activity.setValue(new MessagingExtensionQuery());
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -719,16 +605,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestMessagingExtensionSubmitActionPreviewActionEdit() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setBotMessagePreviewAction("edit");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setBotMessagePreviewAction("edit");
+        activity.setValue(action);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -755,16 +636,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestMessagingExtensionSubmitActionPreviewActionSend() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/submitAction");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setBotMessagePreviewAction("send");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/submitAction");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setBotMessagePreviewAction("send");
+        activity.setValue(action);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -791,16 +667,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestMessagingExtensionFetchTask() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/fetchTask");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setCommandId("testCommand");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/fetchTask");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setCommandId("testCommand");
+        activity.setValue(action);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -826,16 +697,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestMessagingExtensionConfigurationQuerySettingUrl() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/querySettingUrl");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setCommandId("testCommand");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/querySettingUrl");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setCommandId("testCommand");
+        activity.setValue(action);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -864,16 +730,11 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestMessagingExtensionConfigurationSetting() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("composeExtension/setting");
-                setValue(new MessagingExtensionAction() {
-                    {
-                        setCommandId("testCommand");
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("composeExtension/setting");
+        MessagingExtensionAction action = new MessagingExtensionAction();
+        action.setCommandId("testCommand");
+        activity.setValue(action);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -899,26 +760,17 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestTaskModuleFetch() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("task/fetch");
-                setValue(new TaskModuleRequest() {
-                    {
-                        setData(new HashMap<String, Object>() {
-                            {
-                                put("key", "value");
-                                put("type", "task / fetch");
-                            }
-                        });
-                        setContext(new TaskModuleRequestContext() {
-                            {
-                                setTheme("default");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("task/fetch");
+        TaskModuleRequestContext context = new TaskModuleRequestContext();
+        context.setTheme("default");
+        HashMap<String, Object> data = new HashMap<String, Object>();
+        data.put("key", "value");
+        data.put("type", "task / fetch");
+        TaskModuleRequest request = new TaskModuleRequest();
+        request.setData(data);
+        request.setContext(context);
+        activity.setValue(request);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -944,26 +796,17 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestTaskModuleSubmit() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("task/submit");
-                setValue(new TaskModuleRequest() {
-                    {
-                        setData(new HashMap<String, Object>() {
-                            {
-                                put("key", "value");
-                                put("type", "task / fetch");
-                            }
-                        });
-                        setContext(new TaskModuleRequestContext() {
-                            {
-                                setTheme("default");
-                            }
-                        });
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("task/submit");
+        TaskModuleRequestContext context = new TaskModuleRequestContext();
+        context.setTheme("default");
+        HashMap<String, Object> data = new HashMap<String, Object>();
+        data.put("key", "value");
+        data.put("type", "task / fetch");
+        TaskModuleRequest request = new TaskModuleRequest();
+        request.setData(data);
+        request.setContext(context);
+        activity.setValue(request);
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -989,11 +832,8 @@ public class TeamsActivityHandlerTests {
 
     @Test
     public void TestSigninVerifyState() {
-        Activity activity = new Activity(ActivityTypes.INVOKE) {
-            {
-                setName("signin/verifyState");
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.INVOKE);
+        activity.setName("signin/verifyState");
 
         AtomicReference<List<Activity>> activitiesToSend = new AtomicReference<>();
 
@@ -1374,205 +1214,99 @@ public class TeamsActivityHandlerTests {
     private static ConnectorClient getConnectorClient(String baseUri, AppCredentials credentials) {
         Conversations mockConversations = Mockito.mock(Conversations.class);
 
+        ConversationResourceResponse response = new ConversationResourceResponse();
+        response.setId("team-id");
+        response.setServiceUrl("https://serviceUrl/");
+        response.setActivityId("activityId123");
+
         // createConversation
         Mockito.when(
             mockConversations.createConversation(Mockito.any(ConversationParameters.class))
-        ).thenReturn(CompletableFuture.completedFuture(new ConversationResourceResponse() {
-            {
-                setId("team-id");
-                setServiceUrl("https://serviceUrl/");
-                setActivityId("activityId123");
-            }
-        }));
+        ).thenReturn(CompletableFuture.completedFuture(response));
 
+
+        ArrayList<ChannelAccount> channelAccount1 = new ArrayList<ChannelAccount>();
+        ChannelAccount account1 = new ChannelAccount();
+        account1.setId("id-1");
+        account1.setName("name-1");
+        account1.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-1"));
+        account1.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-1"));
+        account1.setProperties("surname", JsonNodeFactory.instance.textNode("surname-1"));
+        account1.setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
+        account1.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-1"));
+        account1.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-1"));
+        channelAccount1.add(account1);
+
+        ChannelAccount account2 = new ChannelAccount();
+        account2.setId("id-2");
+        account2.setName("name-2");
+        account2.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-2"));
+        account2.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-2"));
+        account2.setProperties("surname",JsonNodeFactory.instance.textNode("surname-2"));
+        account2.setProperties("email", JsonNodeFactory.instance.textNode("email-2"));
+        account2.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-2"));
+        account2.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-2"));
+        channelAccount1.add(account2);
         // getConversationMembers (Team)
         Mockito.when(mockConversations.getConversationMembers("team-id")).thenReturn(
-            CompletableFuture.completedFuture(new ArrayList<ChannelAccount>() {
-                {
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-1");
-                            setName("name-1");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-1")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-1")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-1")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-1")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-1")
-                            );
-                        }
-                    });
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-2");
-                            setName("name-2");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-2")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-2")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-2")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-2"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-2")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-2")
-                            );
-                        }
-                    });
-                }
-            })
+            CompletableFuture.completedFuture(channelAccount1)
         );
 
+
+        ArrayList<ChannelAccount> channelAccount2 = new ArrayList<ChannelAccount>();
+        ChannelAccount channelAccount3 = new ChannelAccount();
+        channelAccount3.setId("id-3");
+        channelAccount3.setName("name-3");
+        channelAccount3.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-3"));
+        channelAccount3.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-3"));
+        channelAccount3.setProperties("surname", JsonNodeFactory.instance.textNode("surname-3"));
+        channelAccount3.setProperties("email", JsonNodeFactory.instance.textNode("email-3"));
+        channelAccount3.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-3"));
+        channelAccount3.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-3"));
+        channelAccount2.add(channelAccount3);
+        ChannelAccount channelAccount4 = new ChannelAccount();
+        channelAccount4.setId("id-4");
+        channelAccount4.setName("name-4");
+        channelAccount4.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-4"));
+        channelAccount4.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-4"));
+        channelAccount4.setProperties("surname", JsonNodeFactory.instance.textNode("surname-4"));
+        channelAccount4.setProperties("email", JsonNodeFactory.instance.textNode("email-4"));
+        channelAccount4.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-4"));
+        channelAccount4.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-4"));
+        channelAccount2.add(channelAccount4);
         // getConversationMembers (Group chat)
         Mockito.when(mockConversations.getConversationMembers("conversation-id")).thenReturn(
-            CompletableFuture.completedFuture(new ArrayList<ChannelAccount>() {
-                {
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-3");
-                            setName("name-3");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-3")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-3")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-3")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-3"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-3")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-3")
-                            );
-                        }
-                    });
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-4");
-                            setName("name-4");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-4")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-4")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-4")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-4"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-4")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-4")
-                            );
-                        }
-                    });
-                }
-            })
+            CompletableFuture.completedFuture(channelAccount2)
         );
 
+
+        ChannelAccount channelAccount5 = new ChannelAccount();
+        channelAccount5.setId("id-1");
+        channelAccount5.setName("name-1");
+        channelAccount5.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-1"));
+        channelAccount5.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-1"));
+        channelAccount5.setProperties("surname", JsonNodeFactory.instance.textNode("surname-1"));
+        channelAccount5.setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
+        channelAccount5.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-1"));
+        channelAccount5.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-1"));
         // getConversationMember (Team)
         Mockito.when(mockConversations.getConversationMember("id-1", "team-id")).thenReturn(
-            CompletableFuture.completedFuture(
-                new ChannelAccount() {
-                    {
-                        setId("id-1");
-                        setName("name-1");
-                        setProperties(
-                            "objectId",
-                            JsonNodeFactory.instance.textNode("objectId-1")
-                        );
-                        setProperties(
-                            "givenName",
-                            JsonNodeFactory.instance.textNode("givenName-1")
-                        );
-                        setProperties(
-                            "surname",
-                            JsonNodeFactory.instance.textNode("surname-1")
-                        );
-                        setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
-                        setProperties(
-                            "userPrincipalName",
-                            JsonNodeFactory.instance.textNode("userPrincipalName-1")
-                        );
-                        setProperties(
-                            "tenantId",
-                            JsonNodeFactory.instance.textNode("tenantId-1")
-                        );
-                    }
-                }
-            )
+            CompletableFuture.completedFuture(channelAccount5)
         );
 
+
+        ChannelAccount channelAccount6 = new ChannelAccount();
+        channelAccount6.setId("id-1");
+        channelAccount6.setName("name-1");
+        channelAccount6.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-1"));
+        channelAccount6.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-1"));
+        channelAccount6.setProperties("surname", JsonNodeFactory.instance.textNode("surname-1"));
+        channelAccount6.setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
+        channelAccount6.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-1"));
+        channelAccount6.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-1"));
         // getConversationMember (Group chat)
         Mockito.when(mockConversations.getConversationMember("id-1", "conversation-id")).thenReturn(
-            CompletableFuture.completedFuture(
-                new ChannelAccount() {
-                    {
-                        setId("id-1");
-                        setName("name-1");
-                        setProperties(
-                            "objectId",
-                            JsonNodeFactory.instance.textNode("objectId-1")
-                        );
-                        setProperties(
-                            "givenName",
-                            JsonNodeFactory.instance.textNode("givenName-1")
-                        );
-                        setProperties(
-                            "surname",
-                            JsonNodeFactory.instance.textNode("surname-1")
-                        );
-                        setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
-                        setProperties(
-                            "userPrincipalName",
-                            JsonNodeFactory.instance.textNode("userPrincipalName-1")
-                        );
-                        setProperties(
-                            "tenantId",
-                            JsonNodeFactory.instance.textNode("tenantId-1")
-                        );
-                    }
-                }
-            )
+            CompletableFuture.completedFuture(channelAccount6)
         );
 
         ConnectorClient mockConnectorClient = Mockito.mock(ConnectorClient.class);

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsInfoTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsInfoTests.java
@@ -54,17 +54,12 @@ public class TeamsInfoTests {
         );
         ConnectorClient connectorClient = getConnectorClient(baseUri, credentials);
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setText("Test-SendMessageToTeamsChannelAsync");
-                setChannelId(Channels.MSTEAMS);
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setTeam(new TeamInfo("team-id"));
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+                activity.setText("Test-SendMessageToTeamsChannelAsync");
+        activity.setChannelId(Channels.MSTEAMS);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setTeam(new TeamInfo("team-id"));
+        activity.setChannelData(data);
 
         TurnContext turnContext = new TurnContextImpl(
             new TestBotFrameworkAdapter(
@@ -89,17 +84,12 @@ public class TeamsInfoTests {
         MicrosoftAppCredentials credentials = MicrosoftAppCredentials.empty();
         ConnectorClient connectorClient = getConnectorClient(baseUri, credentials);
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setText("Test-GetTeamDetailsAsync");
-                setChannelId(Channels.MSTEAMS);
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setTeam(new TeamInfo("team-id"));
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText("Test-GetTeamDetailsAsync");
+        activity.setChannelId(Channels.MSTEAMS);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setTeam(new TeamInfo("team-id"));
+        activity.setChannelData(data);
 
         TurnContext turnContext = new TurnContextImpl(new SimpleAdapter(), activity);
         turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, connectorClient);
@@ -119,17 +109,12 @@ public class TeamsInfoTests {
         MicrosoftAppCredentials credentials = MicrosoftAppCredentials.empty();
         ConnectorClient connectorClient = getConnectorClient(baseUri, credentials);
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setText("Test-Team-GetMembersAsync");
-                setChannelId(Channels.MSTEAMS);
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setTeam(new TeamInfo("team-id"));
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText("Test-Team-GetMembersAsync");
+        activity.setChannelId(Channels.MSTEAMS);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setTeam(new TeamInfo("team-id"));
+        activity.setChannelData(data);
 
         TurnContext turnContext = new TurnContextImpl(new SimpleAdapter(), activity);
         turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, connectorClient);
@@ -149,13 +134,10 @@ public class TeamsInfoTests {
         MicrosoftAppCredentials credentials = MicrosoftAppCredentials.empty();
         ConnectorClient connectorClient = getConnectorClient(baseUri, credentials);
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setText("Test-GroupChat-GetMembersAsync");
-                setChannelId(Channels.MSTEAMS);
-                setConversation(new ConversationAccount("conversation-id"));
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText("Test-GroupChat-GetMembersAsync");
+        activity.setChannelId(Channels.MSTEAMS);
+        activity.setConversation(new ConversationAccount("conversation-id"));
 
         TurnContext turnContext = new TurnContextImpl(new SimpleAdapter(), activity);
         turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, connectorClient);
@@ -175,17 +157,12 @@ public class TeamsInfoTests {
         MicrosoftAppCredentials credentials = MicrosoftAppCredentials.empty();
         ConnectorClient connectorClient = getConnectorClient(baseUri, credentials);
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {
-            {
-                setText("Test-GetChannelsAsync");
-                setChannelId(Channels.MSTEAMS);
-                setChannelData(new TeamsChannelData() {
-                    {
-                        setTeam(new TeamInfo("team-id"));
-                    }
-                });
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setText("Test-GetChannelsAsync");
+        activity.setChannelId(Channels.MSTEAMS);
+        TeamsChannelData data = new TeamsChannelData();
+        data.setTeam(new TeamInfo("team-id"));
+        activity.setChannelData(data);
 
         TurnContext turnContext = new TurnContextImpl(new SimpleAdapter(), activity);
         turnContext.getTurnState().add(BotFrameworkAdapter.CONNECTOR_CLIENT_KEY, connectorClient);
@@ -336,139 +313,68 @@ public class TeamsInfoTests {
     private static ConnectorClient getConnectorClient(String baseUri, AppCredentials credentials) {
         Conversations mockConversations = Mockito.mock(Conversations.class);
 
+        ConversationResourceResponse response = new ConversationResourceResponse();
+        response.setId("team-id");
+        response.setServiceUrl("https://serviceUrl/");
+        response.setActivityId("activityId123");
+
         // createConversation
         Mockito.when(
             mockConversations.createConversation(Mockito.any(ConversationParameters.class))
-        ).thenReturn(CompletableFuture.completedFuture(new ConversationResourceResponse() {
-            {
-                setId("team-id");
-                setServiceUrl("https://serviceUrl/");
-                setActivityId("activityId123");
-            }
-        }));
+        ).thenReturn(CompletableFuture.completedFuture(response));
 
+
+        ArrayList<ChannelAccount> channelAccounts1 = new ArrayList<ChannelAccount>();
+        ChannelAccount channelAccount1 = new ChannelAccount();
+        channelAccount1.setId("id-1");
+        channelAccount1.setName("name-1");
+        channelAccount1.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-1"));
+        channelAccount1.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-1"));
+        channelAccount1.setProperties("surname", JsonNodeFactory.instance.textNode("surname-1"));
+        channelAccount1.setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
+        channelAccount1.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-1"));
+        channelAccount1.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-1"));
+        channelAccounts1.add(channelAccount1);
+        ChannelAccount channelAccount2 = new ChannelAccount();
+        channelAccount2.setId("id-2");
+        channelAccount2.setName("name-2");
+        channelAccount2.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-2"));
+        channelAccount2.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-2"));
+        channelAccount2.setProperties("surname", JsonNodeFactory.instance.textNode("surname-2"));
+        channelAccount2.setProperties("email", JsonNodeFactory.instance.textNode("email-2"));
+        channelAccount2.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-2"));
+        channelAccount2.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-2"));
+        channelAccounts1.add(channelAccount2);
         // getConversationMembers (Team)
         Mockito.when(mockConversations.getConversationMembers("team-id")).thenReturn(
-            CompletableFuture.completedFuture(new ArrayList<ChannelAccount>() {
-                {
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-1");
-                            setName("name-1");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-1")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-1")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-1")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-1"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-1")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-1")
-                            );
-                        }
-                    });
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-2");
-                            setName("name-2");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-2")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-2")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-2")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-2"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-2")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-2")
-                            );
-                        }
-                    });
-                }
-            })
+            CompletableFuture.completedFuture(channelAccounts1)
         );
 
+
+        ArrayList<ChannelAccount> channelAccounts2 = new ArrayList<ChannelAccount>();
+        ChannelAccount channelAccount3 = new ChannelAccount();
+        channelAccount3.setId("id-3");
+        channelAccount3.setName("name-3");
+        channelAccount3.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-3"));
+        channelAccount3.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-3"));
+        channelAccount3.setProperties("surname", JsonNodeFactory.instance.textNode("surname-3"));
+        channelAccount3.setProperties("email", JsonNodeFactory.instance.textNode("email-3"));
+        channelAccount3.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-3"));
+        channelAccount3.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-3"));
+        channelAccounts2.add(channelAccount3);
+        ChannelAccount channelAccount4 = new ChannelAccount();
+        channelAccount4.setId("id-4");
+        channelAccount4.setName("name-4");
+        channelAccount4.setProperties("objectId", JsonNodeFactory.instance.textNode("objectId-4"));
+        channelAccount4.setProperties("givenName", JsonNodeFactory.instance.textNode("givenName-4"));
+        channelAccount4.setProperties("surname", JsonNodeFactory.instance.textNode("surname-4"));
+        channelAccount4.setProperties("email", JsonNodeFactory.instance.textNode("email-4"));
+        channelAccount4.setProperties("userPrincipalName", JsonNodeFactory.instance.textNode("userPrincipalName-4"));
+        channelAccount4.setProperties("tenantId", JsonNodeFactory.instance.textNode("tenantId-4"));
+        channelAccounts2.add(channelAccount4);
         // getConversationMembers (Group chat)
         Mockito.when(mockConversations.getConversationMembers("conversation-id")).thenReturn(
-            CompletableFuture.completedFuture(new ArrayList<ChannelAccount>() {
-                {
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-3");
-                            setName("name-3");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-3")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-3")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-3")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-3"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-3")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-3")
-                            );
-                        }
-                    });
-                    add(new ChannelAccount() {
-                        {
-                            setId("id-4");
-                            setName("name-4");
-                            setProperties(
-                                "objectId",
-                                JsonNodeFactory.instance.textNode("objectId-4")
-                            );
-                            setProperties(
-                                "givenName",
-                                JsonNodeFactory.instance.textNode("givenName-4")
-                            );
-                            setProperties(
-                                "surname",
-                                JsonNodeFactory.instance.textNode("surname-4")
-                            );
-                            setProperties("email", JsonNodeFactory.instance.textNode("email-4"));
-                            setProperties(
-                                "userPrincipalName",
-                                JsonNodeFactory.instance.textNode("userPrincipalName-4")
-                            );
-                            setProperties(
-                                "tenantId",
-                                JsonNodeFactory.instance.textNode("tenantId-4")
-                            );
-                        }
-                    });
-                }
-            })
+            CompletableFuture.completedFuture(channelAccounts2)
         );
 
         ConnectorClient mockConnectorClient = Mockito.mock(ConnectorClient.class);
@@ -485,30 +391,25 @@ public class TeamsInfoTests {
     ) {
         TeamsOperations mockOperations = Mockito.mock(TeamsOperations.class);
 
+
+        ConversationList list = new ConversationList();
+        ArrayList<ChannelInfo> conversations = new ArrayList<ChannelInfo>();
+        conversations.add(new ChannelInfo("channel-id-1"));
+        conversations.add(new ChannelInfo("channel-id-2", "channel-name-2"));
+        conversations.add(new ChannelInfo("channel-id-3", "channel-name-3"));
+        list.setConversations(conversations);
         // fetchChannelList
         Mockito.when(mockOperations.fetchChannelList(Mockito.anyString())).thenReturn(
-            CompletableFuture.completedFuture(new ConversationList() {
-                {
-                    setConversations(new ArrayList<ChannelInfo>() {
-                        {
-                            add(new ChannelInfo("channel-id-1"));
-                            add(new ChannelInfo("channel-id-2", "channel-name-2"));
-                            add(new ChannelInfo("channel-id-3", "channel-name-3"));
-                        }
-                    });
-                }
-            })
+            CompletableFuture.completedFuture(list)
         );
 
+        TeamDetails details = new TeamDetails();
+        details.setId("team-id");
+        details.setName("team-name");
+        details.setAadGroupId("team-aadgroupid");
         // fetchTeamDetails
         Mockito.when(mockOperations.fetchTeamDetails(Mockito.anyString())).thenReturn(
-            CompletableFuture.completedFuture(new TeamDetails() {
-                {
-                    setId("team-id");
-                    setName("team-name");
-                    setAadGroupId("team-aadgroupid");
-                }
-            })
+            CompletableFuture.completedFuture(details)
         );
 
         TeamsConnectorClient mockConnectorClient = Mockito.mock(TeamsConnectorClient.class);

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/ChannelValidation.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/ChannelValidation.java
@@ -21,24 +21,24 @@ public final class ChannelValidation {
     }
 
     /**
-     * TO BOT FROM CHANNEL: Token validation parameters when connecting to a bot.
+     * TO BOT FROM CHANNEL.
+     * @return Token validation parameters when connecting to a bot.
      */
-    public static final TokenValidationParameters TOKENVALIDATIONPARAMETERS =
-        new TokenValidationParameters() {
-            {
-                this.validateIssuer = true;
-                this.validIssuers = new ArrayList<String>() {
-                    {
-                        add(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER);
-                    }
-                };
-                this.validateAudience = false;
-                this.validateLifetime = true;
-                this.clockSkew =
-                    Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
-                this.requireSignedTokens = true;
-            }
-        };
+    public static TokenValidationParameters getTokenValidationParameters() {
+        TokenValidationParameters tokenValidationParameters = new TokenValidationParameters();
+        tokenValidationParameters.validateIssuer = true;
+
+        ArrayList<String> validIssuers = new ArrayList<String>();
+        validIssuers.add(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER);
+        tokenValidationParameters.validIssuers = validIssuers;
+
+        tokenValidationParameters.validateAudience = false;
+        tokenValidationParameters.validateLifetime = true;
+        tokenValidationParameters.clockSkew = Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
+        tokenValidationParameters.requireSignedTokens = true;
+
+        return tokenValidationParameters;
+    }
 
     /**
      * Gets the OpenID metadata URL.
@@ -104,7 +104,7 @@ public final class ChannelValidation {
         AuthenticationConfiguration authConfig
     ) {
         JwtTokenExtractor tokenExtractor = new JwtTokenExtractor(
-            TOKENVALIDATIONPARAMETERS,
+            getTokenValidationParameters(),
             getOpenIdMetaDataUrl(),
             AuthenticationConstants.ALLOWED_SIGNING_ALGORITHMS
         );

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/EmulatorValidation.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/EmulatorValidation.java
@@ -20,47 +20,36 @@ public final class EmulatorValidation {
     }
 
     /**
-     * TO BOT FROM EMULATOR: Token validation parameters when connecting to a
-     * channel.
+     * TO BOT FROM EMULATOR.
+     * @return Token validation parameters when connecting to a channel.
      */
-    public static final TokenValidationParameters TOKENVALIDATIONPARAMETERS =
-        new TokenValidationParameters() {
-            {
-                this.validateIssuer = true;
-                this.validIssuers = new ArrayList<String>() {
-                    {
-                        // Auth v3.1, 1.0
-                        add("https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/");
+    public static TokenValidationParameters getTokenValidationParameters() {
+        TokenValidationParameters tokenValidationParameters = new TokenValidationParameters();
+        tokenValidationParameters.validateIssuer = true;
 
-                        // Auth v3.1, 2.0
-                        add(
-                            "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0"
-                        );
+        ArrayList<String> validIssuers = new ArrayList<String>();
+        // Auth v3.1, 1.0
+        validIssuers.add("https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/");
+        // Auth v3.1, 2.0
+        validIssuers.add("https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0");
+        // Auth v3.2, 1.0
+        validIssuers.add("https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/");
+        // Auth v3.2, 2.0
+        validIssuers.add("https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0");
+        // Auth for US Gov, 1.0
+        validIssuers.add("https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/");
+        // Auth for US Gov, 2.0
+        validIssuers.add("https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0");
+        tokenValidationParameters.validIssuers = validIssuers;
 
-                        // Auth v3.2, 1.0
-                        add("https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/");
+        tokenValidationParameters.validateAudience = false;
+        tokenValidationParameters.validateLifetime = true;
+        tokenValidationParameters.clockSkew = Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
 
-                        // Auth v3.2, 2.0
-                        add(
-                            "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0"
-                        );
+        tokenValidationParameters.requireSignedTokens = true;
 
-                        // Auth for US Gov, 1.0
-                        add("https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/");
-
-                        // Auth for US Gov, 2.0
-                        add(
-                            "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0"
-                        );
-                    }
-                };
-                this.validateAudience = false;
-                this.validateLifetime = true;
-                this.clockSkew =
-                    Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
-                this.requireSignedTokens = true;
-            }
-        };
+        return tokenValidationParameters;
+    }
 
     /**
      * Determines if a given Auth header is from the Bot Framework Emulator.
@@ -103,7 +92,7 @@ public final class EmulatorValidation {
 
             // Is the token issues by a source we consider to be the emulator?
             // Not a Valid Issuer. This is NOT a Bot Framework Emulator Token.
-            return TOKENVALIDATIONPARAMETERS.validIssuers.contains(decodedJWT.getIssuer());
+            return getTokenValidationParameters().validIssuers.contains(decodedJWT.getIssuer());
         } catch (Throwable t) {
             return false;
         }
@@ -169,7 +158,7 @@ public final class EmulatorValidation {
             : AuthenticationConstants.TO_BOT_FROM_EMULATOR_OPENID_METADATA_URL;
 
         JwtTokenExtractor tokenExtractor = new JwtTokenExtractor(
-            TOKENVALIDATIONPARAMETERS,
+            getTokenValidationParameters(),
             openIdMetadataUrl,
             AuthenticationConstants.ALLOWED_SIGNING_ALGORITHMS
         );

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/EnterpriseChannelValidation.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/EnterpriseChannelValidation.java
@@ -14,22 +14,21 @@ import java.util.concurrent.CompletableFuture;
  * Enterprise channel auth validation.
  */
 public final class EnterpriseChannelValidation {
-    private static final TokenValidationParameters TOKENVALIDATIONPARAMETERS =
-        new TokenValidationParameters() {
-            {
-                this.validateIssuer = true;
-                this.validIssuers = new ArrayList<String>() {
-                    {
-                        add(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER);
-                    }
-                };
-                this.validateAudience = false;
-                this.validateLifetime = true;
-                this.clockSkew =
-                    Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
-                this.requireSignedTokens = true;
-            }
-        };
+    private static TokenValidationParameters getTokenValidationParameters() {
+        TokenValidationParameters tokenValidationParamaters = new TokenValidationParameters();
+        tokenValidationParamaters.validateIssuer = true;
+
+        ArrayList<String> validIssuers = new ArrayList<String>();
+        validIssuers.add(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER);
+        tokenValidationParamaters.validIssuers = validIssuers;
+
+        tokenValidationParamaters.validateAudience = false;
+        tokenValidationParamaters.validateLifetime = true;
+        tokenValidationParamaters.clockSkew = Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
+        tokenValidationParamaters.requireSignedTokens = true;
+
+        return tokenValidationParamaters;
+    }
 
     private EnterpriseChannelValidation() {
 
@@ -99,7 +98,7 @@ public final class EnterpriseChannelValidation {
 
             .thenCompose(channelService -> {
                 JwtTokenExtractor tokenExtractor = new JwtTokenExtractor(
-                    TOKENVALIDATIONPARAMETERS,
+                    getTokenValidationParameters(),
                     String.format(
                         AuthenticationConstants.TO_BOT_FROM_ENTERPRISE_CHANNEL_OPENID_METADATA_URL_FORMAT,
                         channelService

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/GovernmentChannelValidation.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/GovernmentChannelValidation.java
@@ -17,25 +17,23 @@ public final class GovernmentChannelValidation {
         GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_OPENID_METADATA_URL;
 
     /**
-     * TO BOT FROM GOVERNMENT CHANNEL: Token validation parameters when connecting
-     * to a bot.
+     * TO BOT FROM GOVERNMENT CHANNEL.
+     * @return Token validation parameters when connecting to a bot.
      */
-    public static final TokenValidationParameters TOKENVALIDATIONPARAMETERS =
-        new TokenValidationParameters() {
-            {
-                this.validateIssuer = true;
-                this.validIssuers = new ArrayList<String>() {
-                    {
-                        add(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER);
-                    }
-                };
-                this.validateAudience = false;
-                this.validateLifetime = true;
-                this.clockSkew =
-                    Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
-                this.requireSignedTokens = true;
-            }
-        };
+    public static TokenValidationParameters getTokenValidationParameters() {
+        TokenValidationParameters tokenValidationParameters = new TokenValidationParameters();
+
+        ArrayList<String> validIssuers = new ArrayList<String>();
+        tokenValidationParameters.validIssuers = validIssuers;
+
+        tokenValidationParameters.validateIssuer = true;
+        tokenValidationParameters.validateAudience = false;
+        tokenValidationParameters.validateLifetime = true;
+        tokenValidationParameters.clockSkew = Duration.ofMinutes(AuthenticationConstants.DEFAULT_CLOCKSKEW_MINUTES);
+        tokenValidationParameters.requireSignedTokens = true;
+
+        return tokenValidationParameters;
+    }
 
     private GovernmentChannelValidation() {
 
@@ -107,7 +105,7 @@ public final class GovernmentChannelValidation {
         AuthenticationConfiguration authConfig
     ) {
         JwtTokenExtractor tokenExtractor = new JwtTokenExtractor(
-            TOKENVALIDATIONPARAMETERS,
+            getTokenValidationParameters(),
             getOpenIdMetaDataUrl(),
             AuthenticationConstants.ALLOWED_SIGNING_ALGORITHMS
         );

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/RetryParams.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/RetryParams.java
@@ -23,9 +23,9 @@ public class RetryParams {
      * @return A RetryParams that returns false for {@link #getShouldRetry()}.
      */
     public static RetryParams stopRetrying() {
-        return new RetryParams() {{
-            setShouldRetry(false);
-        }};
+        RetryParams retryParams = new RetryParams();
+        retryParams.setShouldRetry(false);
+        return retryParams;
     }
 
     /**

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/AllowedCallersClaimsValidationTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/AllowedCallersClaimsValidationTests.java
@@ -35,14 +35,22 @@ public class AllowedCallersClaimsValidationTests {
         // Empty allowed callers array
         resultList.add(Pair.of(null, new ArrayList<String>()));
         // Allow any caller
-        resultList.add(Pair.of(primaryAppId, new ArrayList<String>() { { add("*"); } }));
+        ArrayList<String> anyCaller = new ArrayList<String>();
+        anyCaller.add("*");
+        resultList.add(Pair.of(primaryAppId, anyCaller));
         // Specify allowed caller
-        resultList.add((Pair.of(primaryAppId, new ArrayList<String>() { { add(primaryAppId); } })));
+        ArrayList<String> allowedCaller = new ArrayList<String>();
+        allowedCaller.add(primaryAppId);
+        resultList.add((Pair.of(primaryAppId, allowedCaller)));
         // Specify multiple callers
-        resultList.add((Pair.of(primaryAppId, new ArrayList<String>() { { add(primaryAppId);
-                                                                          add(secondaryAppId); } })));
+        ArrayList<String> multipleCallers = new ArrayList<String>();
+        multipleCallers.add(primaryAppId);
+        multipleCallers.add(secondaryAppId);
+        resultList.add((Pair.of(primaryAppId, multipleCallers)));
         // Blocked caller throws exception
-        resultList.add((Pair.of(primaryAppId, new ArrayList<String>() { { add(secondaryAppId); } })));
+        ArrayList<String> blockedCallers = new ArrayList<String>();
+        blockedCallers.add(secondaryAppId);
+        resultList.add((Pair.of(primaryAppId, blockedCallers)));
         return resultList;
     }
 

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/AttachmentsTest.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/AttachmentsTest.java
@@ -16,16 +16,14 @@ public class AttachmentsTest extends BotConnectorTestBase {
     @Test
     public void GetAttachmentInfo() {
 
-        AttachmentData attachment = new AttachmentData() {{
-            setName("bot-framework.png");
-            setType("image/png");
-            setOriginalBase64(encodeToBase64(new File(getClass().getClassLoader().getResource("bot-framework.png").getFile())));
-        }};
+        AttachmentData attachment = new AttachmentData();
+        attachment.setName("bot-framework.png");
+        attachment.setType("image/png");
+        attachment.setOriginalBase64(encodeToBase64(new File(getClass().getClassLoader().getResource("bot-framework.png").getFile())));
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -49,16 +47,14 @@ public class AttachmentsTest extends BotConnectorTestBase {
             e.printStackTrace();
         }
 
-        AttachmentData attachment = new AttachmentData() {{
-            setName("bot_icon.png");
-            setType("image/png");
-            setOriginalBase64(attachmentPayload);
-        }};
+        AttachmentData attachment = new AttachmentData();
+        attachment.setName("bot_icon.png");
+        attachment.setType("image/png");
+        attachment.setOriginalBase64(attachmentPayload);
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/ConversationsTest.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/ConversationsTest.java
@@ -21,17 +21,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void CreateConversation() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Create Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Create Conversation");
 
-        ConversationParameters params = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters params = new ConversationParameters();
+        params.setMembers(Collections.singletonList(user));
+        params.setBot(bot);
+        params.setActivity(activity);
 
         ConversationResourceResponse result = connector.getConversations().createConversation(params).join();
 
@@ -41,18 +39,16 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void CreateConversationWithInvalidBot() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Create Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Create Conversation");
 
         bot.setId("invalid-id");
-        ConversationParameters params = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters params = new ConversationParameters();
+        params.setMembers(Collections.singletonList(user));
+        params.setBot(bot);
+        params.setActivity(activity);
 
         try {
             ConversationResourceResponse result = connector.getConversations().createConversation(params).join();
@@ -70,17 +66,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void CreateConversationWithoutMembers() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Create Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Create Conversation");
 
-        ConversationParameters params = new ConversationParameters() {{
-            setMembers(Collections.<ChannelAccount>emptyList());
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters params = new ConversationParameters();
+        params.setMembers(Collections.<ChannelAccount>emptyList());
+        params.setBot(bot);
+        params.setActivity(activity);
 
         try {
             ConversationResourceResponse result = connector.getConversations().createConversation(params).join();
@@ -98,17 +92,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void CreateConversationWithBotMember() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Create Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Create Conversation");
 
-        ConversationParameters params = new ConversationParameters() {{
-            setMembers(Collections.singletonList(bot));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters params = new ConversationParameters();
+        params.setMembers(Collections.singletonList(bot));
+        params.setBot(bot);
+        params.setActivity(activity);
 
         try {
             ConversationResourceResponse result = connector.getConversations().createConversation(params).join();
@@ -131,10 +123,9 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void GetConversationMembers() {
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -153,10 +144,9 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void GetConversationMembersWithInvalidConversationId() {
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -185,10 +175,9 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void GetConversationPagedMembers() {
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -210,17 +199,15 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void GetConversationPagedMembersWithInvalidConversationId() {
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Get Activity Members");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Get Activity Members");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
+        createMessage.setActivity(activity);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -239,17 +226,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void SendToConversation() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setName("activity");
-            setText("TEST Send to Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setName("activity");
+        activity.setText("TEST Send to Conversation");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -261,17 +246,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void SendToConversationWithInvalidConversationId() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setName("activity");
-            setText("TEST Send to Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setName("activity");
+        activity.setText("TEST Send to Conversation");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -291,20 +274,18 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void SendToConversationWithInvalidBotId() {
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
         bot.setId("B21S8SG7K:T03CWQ0QB");
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setName("activity");
-            setText("TEST Send to Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setName("activity");
+        activity.setText("TEST Send to Conversation");
 
         try {
             ResourceResponse response = connector.getConversations().sendToConversation(conversation.getId(), activity).join();
@@ -321,11 +302,10 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void SendToConversationWithNullConversationId() {
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Send to Conversation with null conversation id");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Send to Conversation with null conversation id");
 
         try {
             connector.getConversations().sendToConversation(null, activity).join();
@@ -349,39 +329,34 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void SendCardToConversation() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setName("activity");
-            setText("TEST Send Card to Conversation");
-            setAttachments(Arrays.asList(
-                new Attachment() {{
-                    setContentType("application/vnd.microsoft.card.hero");
-                    setContent(new HeroCard() {{
-                        setTitle("A static image");
-                        setSubtitle("JPEG image");
-                        setImages(Collections.singletonList(new CardImage() {{
-                            setUrl("https://docs.microsoft.com/en-us/bot-framework/media/designing-bots/core/dialogs-screens.png");
-                        }}));
-                    }});
-                }},
-                new Attachment() {{
-                    setContentType("application/vnd.microsoft.card.hero");
-                    setContent(new HeroCard() {{
-                        setTitle("An animation");
-                        setSubtitle("GIF image");
-                        setImages(Collections.singletonList(new CardImage() {{
-                            setUrl("http://i.giphy.com/Ki55RUbOV5njy.gif");
-                        }}));
-                    }});
-                }}
-            ));
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setName("activity");
+        activity.setText("TEST Send Card to Conversation");
+        CardImage imageJPEG = new CardImage();
+        imageJPEG.setUrl("https://docs.microsoft.com/en-us/bot-framework/media/designing-bots/core/dialogs-screens.png");
+        HeroCard heroCardJPEG = new HeroCard();
+        heroCardJPEG.setTitle("A static image");
+        heroCardJPEG.setSubtitle("JPEG image");
+        heroCardJPEG.setImages(Collections.singletonList(imageJPEG));
+        Attachment attachmentJPEG = new Attachment();
+        attachmentJPEG.setContentType("application/vnd.microsoft.card.hero");
+        attachmentJPEG.setContent(heroCardJPEG);
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        CardImage imageGIF = new CardImage();
+        imageGIF.setUrl("http://i.giphy.com/Ki55RUbOV5njy.gif");
+        HeroCard heroCardGIF = new HeroCard();
+        heroCardGIF.setTitle("An animation");
+        heroCardGIF.setSubtitle("GIF image");
+        heroCardGIF.setImages(Collections.singletonList(imageGIF));
+        Attachment attachmentGIF = new Attachment();
+        attachmentGIF.setContentType("application/vnd.microsoft.card.hero");
+        attachmentGIF.setContent(heroCardGIF);
+        activity.setAttachments(Arrays.asList(attachmentJPEG, attachmentGIF));
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -393,17 +368,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void GetActivityMembers() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Get Activity Members");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Get Activity Members");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
+        createMessage.setActivity(activity);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -422,17 +395,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void GetActivityMembersWithInvalidConversationId() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Get Activity Members");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Get Activity Members");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
+        createMessage.setActivity(activity);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -472,22 +443,19 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void ReplyToActivity() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Send to Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Send to Conversation");
 
-        Activity reply = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Reply to Activity");
-        }};
+        Activity reply = new Activity(ActivityTypes.MESSAGE);
+        reply.setRecipient(user);
+        reply.setFrom(bot);
+        reply.setText("TEST Reply to Activity");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -501,22 +469,19 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void ReplyToActivityWithInvalidConversationId() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Send to Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Send to Conversation");
 
-        Activity reply = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Reply to Activity");
-        }};
+        Activity reply = new Activity(ActivityTypes.MESSAGE);
+        reply.setRecipient(user);
+        reply.setFrom(bot);
+        reply.setText("TEST Reply to Activity");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -537,11 +502,10 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void ReplyToActivityWithNullConversationId() {
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Reply activity with null conversation id");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Reply activity with null conversation id");
 
         try {
             connector.getConversations().replyToActivity(null, "id", activity).join();
@@ -553,11 +517,10 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void ReplyToActivityWithNullActivityId() {
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Reply activity with null activity id");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Reply activity with null activity id");
 
         try {
             connector.getConversations().replyToActivity("id", null, activity).join();
@@ -579,16 +542,14 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void ReplyToActivityWithNullReply() {
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Reply activity with null reply");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Reply activity with null reply");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -605,17 +566,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void DeleteActivity() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Delete Activity");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Delete Activity");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
+        createMessage.setActivity(activity);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -627,17 +586,15 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void DeleteActivityWithInvalidConversationId() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Delete Activity");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Delete Activity");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-            setActivity(activity);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
+        createMessage.setActivity(activity);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -677,16 +634,14 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void UpdateActivity() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Send to Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Send to Conversation");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -703,16 +658,14 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void UpdateActivityWithInvalidConversationId() {
 
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Send to Conversation");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Send to Conversation");
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 
@@ -736,11 +689,10 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void UpdateActivityWithNullConversationId() {
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Activity to be updated with null conversation Id");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Activity to be updated with null conversation Id");
 
         try {
             connector.getConversations().updateActivity(null, "id", activity).join();
@@ -752,11 +704,10 @@ public class ConversationsTest extends BotConnectorTestBase {
 
     @Test
     public void UpdateActivityWithNullActivityId() {
-        Activity activity = new Activity(ActivityTypes.MESSAGE) {{
-            setRecipient(user);
-            setFrom(bot);
-            setText("TEST Activity to be updated with null activity Id");
-        }};
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setRecipient(user);
+        activity.setFrom(bot);
+        activity.setText("TEST Activity to be updated with null activity Id");
 
         try {
             connector.getConversations().updateActivity("id", null, activity).join();
@@ -779,16 +730,14 @@ public class ConversationsTest extends BotConnectorTestBase {
     @Test
     public void UploadAttachment() {
 
-        AttachmentData attachment = new AttachmentData() {{
-            setName("bot-framework.png");
-            setType("image/png");
-            setOriginalBase64(encodeToBase64(new File(getClass().getClassLoader().getResource("bot-framework.png").getFile())));
-        }};
+        AttachmentData attachment = new AttachmentData();
+        attachment.setName("bot-framework.png");
+        attachment.setType("image/png");
+        attachment.setOriginalBase64(encodeToBase64(new File(getClass().getClassLoader().getResource("bot-framework.png").getFile())));
 
-        ConversationParameters createMessage = new ConversationParameters() {{
-            setMembers(Collections.singletonList(user));
-            setBot(bot);
-        }};
+        ConversationParameters createMessage = new ConversationParameters();
+        createMessage.setMembers(Collections.singletonList(user));
+        createMessage.setBot(bot);
 
         ConversationResourceResponse conversation = connector.getConversations().createConversation(createMessage).join();
 

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/JwtTokenExtractorTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/JwtTokenExtractorTests.java
@@ -54,9 +54,9 @@ public class JwtTokenExtractorTests {
 
     @Before
     public void setup() throws GeneralSecurityException, IOException {
-        ChannelValidation.TOKENVALIDATIONPARAMETERS.validateLifetime = false;
-        EmulatorValidation.TOKENVALIDATIONPARAMETERS.validateLifetime = false;
-        GovernmentChannelValidation.TOKENVALIDATIONPARAMETERS.validateLifetime = false;
+        ChannelValidation.getTokenValidationParameters().validateLifetime = false;
+        EmulatorValidation.getTokenValidationParameters().validateLifetime = false;
+        GovernmentChannelValidation.getTokenValidationParameters().validateLifetime = false;
 
         valid = loadCert("bot-connector.pkcs12");
         expired = loadCert("bot-connector-expired.pkcs12");
@@ -132,26 +132,26 @@ public class JwtTokenExtractorTests {
 
     private static TokenValidationParameters createTokenValidationParameters(X509Certificate cert)
     {
-        return new TokenValidationParameters() {{
-            validateIssuer = false;
-            validIssuers = Collections.singletonList(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER);
+        TokenValidationParameters parameters = new TokenValidationParameters();
+        parameters.validateIssuer = false;
+        parameters.validIssuers = Collections.singletonList(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER);
 
-            // Audience validation takes place in JwtTokenExtractor
-            validateAudience = false;
-            validateLifetime = true;
-            clockSkew = Duration.ofMinutes(5);
-            requireSignedTokens = true;
+        // Audience validation takes place in JwtTokenExtractor
+        parameters.validateAudience = false;
+        parameters.validateLifetime = true;
+        parameters.clockSkew = Duration.ofMinutes(5);
+        parameters.requireSignedTokens = true;
 
-            // provide a custom resolver so that calls to openid won't happen (which wouldn't
-            // work for these tests).
-            issuerSigningKeyResolver = key -> (OpenIdMetadata) keyId -> {
-                // return our certificate data
-                OpenIdMetadataKey key1 = new OpenIdMetadataKey();
-                key1.key = (RSAPublicKey) cert.getPublicKey();
-                key1.certificateChain = Collections.singletonList(encodeCertificate(cert));
-                return key1;
-            };
-        }};
+        // provide a custom resolver so that calls to openid won't happen (which wouldn't
+        // work for these tests).
+        parameters.issuerSigningKeyResolver = key -> (OpenIdMetadata) keyId -> {
+            // return our certificate data
+            OpenIdMetadataKey key1 = new OpenIdMetadataKey();
+            key1.key = (RSAPublicKey) cert.getPublicKey();
+            key1.certificateChain = Collections.singletonList(encodeCertificate(cert));
+            return key1;
+        };
+        return parameters;
     }
 
     private static class CertInfo {
@@ -166,12 +166,12 @@ public class JwtTokenExtractorTests {
         KeyStore p12 = KeyStore.getInstance("pkcs12");
         p12.load(fis, "botframework".toCharArray());
 
-        return new CertInfo() {{
-            cert = (X509Certificate) p12.getCertificate("bot-connector-pkcs12");
-            keypair = new KeyPair(cert.getPublicKey(),
-                (PrivateKey) p12.getKey("bot-connector-pkcs12", "botframework".toCharArray())
-            );
-        }};
+        CertInfo certInfo = new CertInfo();
+        certInfo.cert = (X509Certificate) p12.getCertificate("bot-connector-pkcs12");
+        certInfo.keypair = new KeyPair(certInfo.cert.getPublicKey(),
+            (PrivateKey) p12.getKey("bot-connector-pkcs12", "botframework".toCharArray())
+        );
+        return certInfo;
     }
 
     private static String encodeCertificate(Certificate certificate) {

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/JwtTokenValidationTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/JwtTokenValidationTests.java
@@ -5,6 +5,7 @@ package com.microsoft.bot.connector;
 
 import com.microsoft.bot.connector.authentication.*;
 import com.microsoft.bot.schema.Activity;
+import com.microsoft.bot.schema.ActivityTypes;
 import com.microsoft.bot.schema.ChannelAccount;
 import com.microsoft.bot.schema.ConversationReference;
 import com.microsoft.bot.schema.RoleTypes;
@@ -161,10 +162,10 @@ public class JwtTokenValidationTests {
     public void ChannelMsaHeaderValidServiceUrlShouldBeTrusted() throws IOException, ExecutionException, InterruptedException {
         String header = getHeaderToken();
         CredentialProvider credentials = new SimpleCredentialProvider(APPID, "");
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/");
         JwtTokenValidation.authenticateRequest(
-            new Activity() {{
-                setServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/");
-            }},
+            activity,
             header,
             credentials,
             new SimpleChannelProvider()).join();
@@ -181,10 +182,10 @@ public class JwtTokenValidationTests {
         CredentialProvider credentials = new SimpleCredentialProvider("7f74513e-6f96-4dbc-be9d-9a81fea22b88", "");
 
         try {
+            Activity activity = new Activity(ActivityTypes.MESSAGE);
+            activity.setServiceUrl("https://webchat.botframework.com/");
             JwtTokenValidation.authenticateRequest(
-                new Activity() {{
-                    setServiceUrl("https://webchat.botframework.com/");
-                }},
+                activity,
                 header,
                 credentials,
                 new SimpleChannelProvider()).join();
@@ -203,10 +204,10 @@ public class JwtTokenValidationTests {
         String header = "";
         CredentialProvider credentials = new SimpleCredentialProvider("", "");
 
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setServiceUrl("https://webchat.botframework.com/");
         ClaimsIdentity identity = JwtTokenValidation.authenticateRequest(
-            new Activity() {{
-                setServiceUrl("https://webchat.botframework.com/");
-            }},
+            activity,
             header,
             credentials,
             new SimpleChannelProvider()).join();
@@ -221,13 +222,15 @@ public class JwtTokenValidationTests {
         String header = "";
         CredentialProvider credentials = new SimpleCredentialProvider("", "");
 
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setServiceUrl("https://webchat.botframework.com/");
+        activity.setChannelId(Channels.EMULATOR);
+        activity.setRelatesTo(new ConversationReference());
+        ChannelAccount skillAccount = new ChannelAccount();
+        skillAccount.setRole(RoleTypes.SKILL);
+        activity.setRecipient(skillAccount);
         ClaimsIdentity identity = JwtTokenValidation.authenticateRequest(
-            new Activity() {{
-                setServiceUrl("https://webchat.botframework.com/");
-                setChannelId(Channels.EMULATOR);
-                setRelatesTo(new ConversationReference());
-                setRecipient(new ChannelAccount() { { setRole(RoleTypes.SKILL); } });
-            }},
+            activity,
             header,
             credentials,
             new SimpleChannelProvider()).join();
@@ -241,10 +244,10 @@ public class JwtTokenValidationTests {
         try {
             String header = "";
             CredentialProvider credentials = new SimpleCredentialProvider(APPID, APPPASSWORD);
+            Activity activity = new Activity(ActivityTypes.MESSAGE);
+            activity.setServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/");
             JwtTokenValidation.authenticateRequest(
-                new Activity() {{
-                    setServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/");
-                }},
+                activity,
                 header,
                 credentials,
                 new SimpleChannelProvider()).join();
@@ -264,10 +267,10 @@ public class JwtTokenValidationTests {
         String header = "";
         CredentialProvider credentials = new SimpleCredentialProvider("", "");
 
+        Activity activity = new Activity(ActivityTypes.MESSAGE);
+        activity.setServiceUrl("https://webchat.botframework.com/");
         ClaimsIdentity identity = JwtTokenValidation.authenticateRequest(
-            new Activity() {{
-                setServiceUrl("https://webchat.botframework.com/");
-            }},
+            activity,
             header,
             credentials,
             new SimpleChannelProvider()).join();
@@ -280,10 +283,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -299,10 +301,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(null, claims);
 
         try {
@@ -319,9 +320,8 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -338,10 +338,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, "");
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, "");
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -358,10 +357,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, "abc");
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, "abc");
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -378,9 +376,8 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
         ClaimsIdentity identity = new ClaimsIdentity(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -397,10 +394,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, "");
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, "");
         ClaimsIdentity identity = new ClaimsIdentity(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -417,10 +413,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, null);
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, "other");
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, "other");
         ClaimsIdentity identity = new ClaimsIdentity(AuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -437,10 +432,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -456,10 +450,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(null, claims);
 
         try {
@@ -476,9 +469,8 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -495,10 +487,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, "");
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, "");
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -515,10 +506,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, "abc");
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, "abc");
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -535,10 +525,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, serviceUrl);
         ClaimsIdentity identity = new ClaimsIdentity("https://wrongissuer.com", claims);
 
         try {
@@ -555,9 +544,8 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
         ClaimsIdentity identity = new ClaimsIdentity(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -574,10 +562,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, "");
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, "");
         ClaimsIdentity identity = new ClaimsIdentity(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {
@@ -594,10 +581,9 @@ public class JwtTokenValidationTests {
         String serviceUrl = "https://webchat.botframework.com/";
         CredentialProvider credentials = new SimpleCredentialProvider(appId, "");
 
-        Map<String, String> claims = new HashMap<String, String>() {{
-            put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
-            put(AuthenticationConstants.SERVICE_URL_CLAIM, "other");
-        }};
+        Map<String, String> claims = new HashMap<String, String>();
+        claims.put(AuthenticationConstants.AUDIENCE_CLAIM, appId);
+        claims.put(AuthenticationConstants.SERVICE_URL_CLAIM, "other");
         ClaimsIdentity identity = new ClaimsIdentity(GovernmentAuthenticationConstants.TO_BOT_FROM_CHANNEL_TOKEN_ISSUER, claims);
 
         try {

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/RetryTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/RetryTests.java
@@ -15,9 +15,8 @@ import java.util.concurrent.CompletionException;
 public class RetryTests {
     @Test
     public void Retry_NoRetryWhenTaskSucceeds() {
-        FaultyClass faultyClass = new FaultyClass() {{
-           exceptionToThrow = null;
-        }};
+        FaultyClass faultyClass = new FaultyClass();
+        faultyClass.exceptionToThrow = null;
 
         Retry.run(() ->
             faultyClass.faultyTask(),
@@ -30,10 +29,9 @@ public class RetryTests {
 
     @Test
     public void Retry_RetryThenSucceed() {
-        FaultyClass faultyClass = new FaultyClass() {{
-            exceptionToThrow = new IllegalArgumentException();
-            triesUntilSuccess = 3;
-        }};
+        FaultyClass faultyClass = new FaultyClass();
+        faultyClass.exceptionToThrow = new IllegalArgumentException();
+        faultyClass.triesUntilSuccess = 3;
 
         Retry.run(() ->
             faultyClass.faultyTask(),
@@ -46,10 +44,9 @@ public class RetryTests {
 
     @Test
     public void Retry_RetryUntilFailure() {
-        FaultyClass faultyClass = new FaultyClass() {{
-            exceptionToThrow = new IllegalArgumentException();
-            triesUntilSuccess = 12;
-        }};
+        FaultyClass faultyClass = new FaultyClass();
+        faultyClass.exceptionToThrow = new IllegalArgumentException();
+        faultyClass.triesUntilSuccess = 12;
 
         try {
             Retry.run(() ->

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/DialogContext.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/DialogContext.java
@@ -495,11 +495,10 @@ public class DialogContext {
      */
     public CompletableFuture<Boolean> emitEvent(String name, Object value, boolean bubble, boolean fromLeaf) {
         // Initialize event
-        DialogEvent dialogEvent = new DialogEvent() {{
-            setBubble(bubble);
-            setName(name);
-            setValue(value);
-        }};
+        DialogEvent dialogEvent = new DialogEvent();
+        dialogEvent.setBubble(bubble);
+        dialogEvent.setName(name);
+        dialogEvent.setValue(value);
 
         DialogContext dc = this;
 

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/Recognizer.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/Recognizer.java
@@ -160,14 +160,18 @@ public class Recognizer {
 
         if (!candidates.isEmpty()) {
             // return ChooseIntent with candidates array
-            intents.put(CHOOSE_INTENT, new IntentScore() {{ setScore(1.0); }});
+            IntentScore intent = new IntentScore();
+            intent.setScore(1.0);
+            intents.put(CHOOSE_INTENT, intent);
 
             result.setText(text);
             result.setIntents(intents);
             result.setProperties("candidates", Serialization.objectToTree(candidates));
         } else {
             // just return a none intent
-            intents.put(NONE_INTENT, new IntentScore() {{ setScore(1.0); }});
+            IntentScore intent = new IntentScore();
+            intent.setScore(1.0);
+            intents.put(NONE_INTENT, intent);
 
             result.setText(text);
             result.setIntents(intents);

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/choices/ChoiceFactory.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/choices/ChoiceFactory.java
@@ -345,12 +345,9 @@ public final class ChoiceFactory {
      * @return The created Activity.
      */
     public static Activity heroCard(List<Choice> choices, String text, String speak) {
-        HeroCard card = new HeroCard() {
-            {
-                setText(text);
-                setButtons(extractActions(choices));
-            }
-        };
+        HeroCard card = new HeroCard();
+        card.setText(text);
+        card.setButtons(extractActions(choices));
 
         List<Attachment> attachments = new ArrayList<Attachment>() {
             /**
@@ -398,13 +395,11 @@ public final class ChoiceFactory {
                 return choice.getAction();
             }
 
-            return new CardAction() {
-                {
-                    setType(ActionTypes.IM_BACK);
-                    setValue(choice.getValue());
-                    setTitle(choice.getValue());
-                }
-            };
+            CardAction card = new CardAction();
+            card.setType(ActionTypes.IM_BACK);
+            card.setValue(choice.getValue());
+            card.setTitle(choice.getValue());
+            return card;
         }).collect(Collectors.toList());
     }
 }

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/choices/ChoiceRecognizers.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/choices/ChoiceRecognizers.java
@@ -109,17 +109,17 @@ public final class ChoiceRecognizers {
             int index = Integer.parseInt(value) - 1;
             if (index >= 0 && index < list.size()) {
                 Choice choice = list.get(index);
-                matched.add(new ModelResult<FoundChoice>() {{
-                    setStart(match.getStart());
-                    setEnd(match.getEnd());
-                    setTypeName("choice");
-                    setText(match.getText());
-                    setResolution(new FoundChoice() {{
-                        setValue(choice.getValue());
-                        setIndex(index);
-                        setScore(1.0f);
-                    }});
-                }});
+                FoundChoice resolution = new FoundChoice();
+                resolution.setValue(choice.getValue());
+                resolution.setIndex(index);
+                resolution.setScore(1.0f);
+                ModelResult<FoundChoice> modelResult = new ModelResult<FoundChoice>();
+                modelResult.setStart(match.getStart());
+                modelResult.setEnd(match.getEnd());
+                modelResult.setTypeName("choice");
+                modelResult.setText(match.getText());
+                modelResult.setResolution(resolution);
+                matched.add(modelResult);
             }
         } catch (Throwable ignored) {
             // noop here, as in dotnet/node repos
@@ -128,14 +128,15 @@ public final class ChoiceRecognizers {
 
     private static List<ModelResult<FoundChoice>> recognizeNumbers(String utterance, IModel model) {
         List<com.microsoft.recognizers.text.ModelResult> result = model.parse(utterance == null ? "" : utterance);
-        return result.stream().map(r ->
-            new ModelResult<FoundChoice>() {{
-            setStart(r.start);
-            setEnd(r.end);
-            setText(r.text);
-            setResolution(new FoundChoice() {{
-                setValue(r.resolution.get("value").toString());
-            }});
-        }}).collect(Collectors.toList());
+        return result.stream().map(r -> {
+            FoundChoice resolution = new FoundChoice();
+            resolution.setValue(r.resolution.get("value").toString());
+            ModelResult<FoundChoice> modelResult = new ModelResult<FoundChoice>();
+            modelResult.setStart(r.start);
+            modelResult.setEnd(r.end);
+            modelResult.setText(r.text);
+            modelResult.setResolution(resolution);
+            return modelResult;
+        }).collect(Collectors.toList());
     }
 }

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/choices/Find.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/choices/Find.java
@@ -104,18 +104,18 @@ public final class Find {
         return findValues(utterance, synonyms, options).stream().map(v -> {
             Choice choice = choices.get(v.getResolution().getIndex());
 
-            return new ModelResult<FoundChoice>() {{
-                setStart(v.getStart());
-                setEnd(v.getEnd());
-                setTypeName("choice");
-                setText(v.getText());
-                setResolution(new FoundChoice() {{
-                    setValue(choice.getValue());
-                    setIndex(v.getResolution().getIndex());
-                    setScore(v.getResolution().getScore());
-                    setSynonym(v.getResolution().getValue());
-                }});
-            }};
+            FoundChoice resolution = new FoundChoice();
+            resolution.setValue(choice.getValue());
+            resolution.setIndex(v.getResolution().getIndex());
+            resolution.setScore(v.getResolution().getScore());
+            resolution.setSynonym(v.getResolution().getValue());
+            ModelResult<FoundChoice> modelResult = new ModelResult<FoundChoice>();
+            modelResult.setStart(v.getStart());
+            modelResult.setEnd(v.getEnd());
+            modelResult.setTypeName("choice");
+            modelResult.setText(v.getText());
+            modelResult.setResolution(resolution);
+            return modelResult;
         }).collect(Collectors.toList());
     }
 
@@ -295,15 +295,15 @@ public final class Find {
             float score = completeness * accuracy;
 
             // Format result
+            FoundValue resolution = new FoundValue();
+            resolution.setValue(value);
+            resolution.setIndex(index);
+            resolution.setScore(score);
             result = new ModelResult<>();
             result.setStart(start);
             result.setEnd(end);
             result.setTypeName("value");
-            result.setResolution(new FoundValue() {{
-                setValue(value);
-                setIndex(index);
-                setScore(score);
-            }});
+            result.setResolution(resolution);
         }
 
         return result;

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/ChoicePrompt.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/ChoicePrompt.java
@@ -75,15 +75,12 @@ public class ChoicePrompt extends Prompt<FoundChoice> {
 
         choiceDefaults = new HashMap<String, ChoiceFactoryOptions>();
         for (PromptCultureModel model : PromptCultureModels.getSupportedCultures()) {
-            choiceDefaults.put(model.getLocale(), new ChoiceFactoryOptions() {
-                {
-                    setInlineSeparator(model.getSeparator());
-                    setInlineOr(model.getInlineOr());
-                    setInlineOrMore(model.getInlineOrMore());
-                    setIncludeNumbers(true);
-                }
-            }
-            );
+            ChoiceFactoryOptions options = new ChoiceFactoryOptions();
+            options.setInlineSeparator(model.getSeparator());
+            options.setInlineOr(model.getInlineOr());
+            options.setInlineOrMore(model.getInlineOrMore());
+            options.setIncludeNumbers(true);
+            choiceDefaults.put(model.getLocale(), options);
         }
 
         this.style = ListStyle.AUTO;

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/ConfirmPrompt.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/ConfirmPrompt.java
@@ -79,14 +79,11 @@ public class ConfirmPrompt extends Prompt<Boolean> {
         for (PromptCultureModel model : PromptCultureModels.getSupportedCultures()) {
             Choice yesChoice = new Choice(model.getYesInLanguage());
             Choice noChoice = new Choice(model.getNoInLanguage());
-            ChoiceFactoryOptions factoryOptions = new ChoiceFactoryOptions() {
-                {
-                    setInlineSeparator(model.getSeparator());
-                    setInlineOr(model.getInlineOr());
-                    setInlineOrMore(model.getInlineOrMore());
-                    setIncludeNumbers(true);
-                }
-            };
+            ChoiceFactoryOptions factoryOptions = new ChoiceFactoryOptions();
+            factoryOptions.setInlineSeparator(model.getSeparator());
+            factoryOptions.setInlineOr(model.getInlineOr());
+            factoryOptions.setInlineOrMore(model.getInlineOrMore());
+            factoryOptions.setIncludeNumbers(true);
             choiceDefaults.put(model.getLocale(), new Triplet<Choice,
                                                               Choice,
                                                               ChoiceFactoryOptions>(yesChoice,
@@ -312,12 +309,9 @@ public class ConfirmPrompt extends Prompt<Boolean> {
                     // The text may be a number in which case we will interpret that as a choice.
                     Pair<Choice, Choice> confirmedChoices = confirmChoices != null ? confirmChoices
                                             : new Pair<Choice, Choice>(defaults.getValue0(), defaults.getValue1());
-                    ArrayList<Choice> choices = new ArrayList<Choice>() {
-                        {
-                            add(confirmedChoices.getValue0());
-                            add(confirmedChoices.getValue1());
-                        }
-                    };
+                    ArrayList<Choice> choices = new ArrayList<Choice>();
+                    choices.add(confirmedChoices.getValue0());
+                    choices.add(confirmedChoices.getValue1());
 
                     List<ModelResult<FoundChoice>> secondAttemptResults =
                             ChoiceRecognizers.recognizeChoices(utterance, choices);

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/OAuthPrompt.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/OAuthPrompt.java
@@ -407,11 +407,11 @@ public class OAuthPrompt extends Dialog {
 
                     result.setSucceeded(true);
                     TokenResponse finalResponse = tokenExchangeResponse;
-                    result.setValue(new TokenResponse() { {
-                        setChannelId(finalResponse.getChannelId());
-                        setConnectionName(finalResponse.getConnectionName());
-                        setToken(finalResponse.getToken());
-                    }});
+                    TokenResponse response = new TokenResponse();
+                    response.setChannelId(finalResponse.getChannelId());
+                    response.setConnectionName(finalResponse.getConnectionName());
+                    response.setToken(finalResponse.getToken());
+                    result.setValue(response);
                 }
             }
         } else if (turnContext.getActivity().getType().equals(ActivityTypes.MESSAGE)) {

--- a/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/ObjectPathTests.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/ObjectPathTests.java
@@ -233,16 +233,16 @@ public class ObjectPathTests {
 
     @Test
     public void jsonNode_OnlyDefaultTest() {
-        JsonNode defaultOptions = Serialization.objectToTree(new Options() {{
-            lastName = "Smith";
-            firstName = "Fred";
-            age = 22;
-            bool = true;
-            location = new Location() {{
-                latitude = 1.2312312F;
-                longitude = 3.234234F;
-            }};
-        }});
+        Options options = new Options();
+        options.lastName = "Smith";
+        options.firstName = "Fred";
+        options.age = 22;
+        options.bool = true;
+        Location location = new Location();
+        location.latitude = 1.2312312F;
+        location.longitude = 3.234234F;
+        options.location = location;
+        JsonNode defaultOptions = Serialization.objectToTree(options);
 
         JsonNode overlay = Serialization.objectToTree(new Options());
 
@@ -262,16 +262,16 @@ public class ObjectPathTests {
     public void jsonNode_OnlyOverlay() {
         JsonNode defaultOptions = Serialization.objectToTree(new Options());
 
-        JsonNode overlay = Serialization.objectToTree(new Options() {{
-            lastName = "Smith";
-            firstName = "Fred";
-            age = 22;
-            bool = true;
-            location = new Location() {{
-                latitude = 1.2312312F;
-                longitude = 3.234234F;
-            }};
-        }});
+        Options options = new Options();
+        options.lastName = "Smith";
+        options.firstName = "Fred";
+        options.age = 22;
+        options.bool = true;
+        Location location = new Location();
+        location.latitude = 1.2312312F;
+        location.longitude = 3.234234F;
+        options.location = location;
+        JsonNode overlay = Serialization.objectToTree(options);
 
 
         Options result = ObjectPath.assign(defaultOptions, overlay, Options.class);
@@ -288,27 +288,27 @@ public class ObjectPathTests {
 
     @Test
     public void jsonNode_FullOverlay() {
-        JsonNode defaultOptions = Serialization.objectToTree(new Options() {{
-            lastName = "Smith";
-            firstName = "Fred";
-            age = 22;
-            bool = true;
-            location = new Location() {{
-                latitude = 1.2312312F;
-                longitude = 3.234234F;
-            }};
-        }});
+        Options defaultOpts = new Options();
+        defaultOpts.lastName = "Smith";
+        defaultOpts.firstName = "Fred";
+        defaultOpts.age = 22;
+        defaultOpts.bool = true;
+        Location defaultLocation = new Location();
+        defaultLocation.latitude = 1.2312312F;
+        defaultLocation.longitude = 3.234234F;
+        defaultOpts.location = defaultLocation;
+        JsonNode defaultOptions = Serialization.objectToTree(defaultOpts);
 
-        JsonNode overlay = Serialization.objectToTree(new Options() {{
-            lastName = "Grant";
-            firstName = "Eddit";
-            age = 32;
-            bool = false;
-            location = new Location() {{
-                latitude = 2.2312312F;
-                longitude = 2.234234F;
-            }};
-        }});
+        Options overlayOpts = new Options();
+        overlayOpts.lastName = "Grant";
+        overlayOpts.firstName = "Eddit";
+        overlayOpts.age = 32;
+        overlayOpts.bool = false;
+        Location overlayLocation = new Location();
+        overlayLocation.latitude = 2.2312312F;
+        overlayLocation.longitude = 2.234234F;
+        overlayOpts.location = overlayLocation;
+        JsonNode overlay = Serialization.objectToTree(overlayOpts);
 
 
         Options result = ObjectPath.assign(defaultOptions, overlay, Options.class);
@@ -325,20 +325,20 @@ public class ObjectPathTests {
 
     @Test
     public void jsonNode_PartialOverlay() {
-        JsonNode defaultOptions = Serialization.objectToTree(new Options() {{
-            lastName = "Smith";
-            firstName = "Fred";
-            age = 22;
-            bool = true;
-            location = new Location() {{
-                latitude = 1.2312312F;
-                longitude = 3.234234F;
-            }};
-        }});
+        Options defaultOpts = new Options();
+        defaultOpts.lastName = "Smith";
+        defaultOpts.firstName = "Fred";
+        defaultOpts.age = 22;
+        defaultOpts.bool = true;
+        Location defaultLocation = new Location();
+        defaultLocation.latitude = 1.2312312F;
+        defaultLocation.longitude = 3.234234F;
+        defaultOpts.location = defaultLocation;
+        JsonNode defaultOptions = Serialization.objectToTree(defaultOpts);
 
-        JsonNode overlay = Serialization.objectToTree(new Options() {{
-            lastName = "Grant";
-        }});
+        Options overlayOpts = new Options();
+        overlayOpts.lastName = "Grant";
+        JsonNode overlay = Serialization.objectToTree(overlayOpts);
 
 
         Options result = ObjectPath.assign(defaultOptions, overlay, Options.class);

--- a/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/choices/ChoiceFactoryTests.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/choices/ChoiceFactoryTests.java
@@ -54,7 +54,10 @@ public class ChoiceFactoryTests {
 
     @Test
     public void shouldRenderUnincludedNumbersChoicesAsAList() {
-        Activity activity = ChoiceFactory.list(colorChoices, "select from:", null, new ChoiceFactoryOptions() {{ setIncludeNumbers(false); }});
+        ChoiceFactoryOptions choiceFactoryOptions  = new ChoiceFactoryOptions();
+        choiceFactoryOptions.setIncludeNumbers(false);
+
+        Activity activity = ChoiceFactory.list(colorChoices, "select from:", null, choiceFactoryOptions);
         Assert.assertEquals("select from:\n\n   - red\n   - green\n   - blue", activity.getText());
     }
 

--- a/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/choices/ChoicesChannelTests.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/choices/ChoicesChannelTests.java
@@ -9,6 +9,7 @@ import com.microsoft.bot.builder.TurnContextImpl;
 import com.microsoft.bot.connector.Channels;
 import com.microsoft.bot.connector.authentication.SimpleCredentialProvider;
 import com.microsoft.bot.schema.Activity;
+import com.microsoft.bot.schema.ActivityTypes;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -117,7 +118,8 @@ public class ChoicesChannelTests {
 
     @Test
     public void shouldReturnChannelIdFromContextActivity() {
-        Activity testActivity = new Activity() {{ setChannelId(Channels.FACEBOOK); }};
+        Activity testActivity = new Activity(ActivityTypes.MESSAGE);
+        testActivity.setChannelId(Channels.FACEBOOK);
         TurnContext testContext = new TurnContextImpl(new BotFrameworkAdapter(new SimpleCredentialProvider()), testActivity);
         String channelId = Channel.getChannelId(testContext);
         Assert.assertEquals(Channels.FACEBOOK, channelId);
@@ -125,7 +127,8 @@ public class ChoicesChannelTests {
 
     @Test
     public void shouldReturnEmptyFromContextActivityMissingChannel() {
-        Activity testActivity = new Activity() {{ setChannelId(null); }};
+        Activity testActivity = new Activity(ActivityTypes.MESSAGE);
+        testActivity.setChannelId(null);
         TurnContext testContext = new TurnContextImpl(new BotFrameworkAdapter(new SimpleCredentialProvider()), testActivity);
         String channelId = Channel.getChannelId(testContext);
         Assert.assertNull(channelId);

--- a/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/choices/ChoicesRecognizerTests.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/choices/ChoicesRecognizerTests.java
@@ -72,7 +72,9 @@ public class ChoicesRecognizerTests {
 
     @Test
     public void shouldCorrectlyDisambiguateBetweenVerySimilarValues() {
-        List<ModelResult<FoundValue>> found = Find.findValues("option B", similarValues, new FindChoicesOptions() {{ setAllowPartialMatches(true);}});
+        FindChoicesOptions options = new FindChoicesOptions();
+        options.setAllowPartialMatches(true);
+        List<ModelResult<FoundValue>> found = Find.findValues("option B", similarValues, options);
         Assert.assertEquals(1, found.size());
         assertValue(found.get(0), "option B", 1, 1.0f);
     }
@@ -169,19 +171,24 @@ public class ChoicesRecognizerTests {
 
     @Test
     public void shouldNOTFindAChoiceInAnUtteranceByOrdinalPosition_RecognizeOrdinalsFalseAndRecognizeNumbersFalse() {
+        FindChoicesOptions options = new FindChoicesOptions();
+        options.setRecognizeOrdinals(false);
+        options.setRecognizeNumbers(false);
         List<ModelResult<FoundChoice>> found = ChoiceRecognizers.recognizeChoicesFromStrings(
             "the first one please.",
             colorChoices,
-            new FindChoicesOptions() {{ setRecognizeOrdinals(false); setRecognizeNumbers(false);}});
+            options);
         Assert.assertEquals(0, found.size());
     }
 
     @Test
     public void shouldNOTFindAChoiceInAnUtteranceByNumericalIndex_Text_RecognizeNumbersFalse() {
+        FindChoicesOptions options = new FindChoicesOptions();
+        options.setRecognizeNumbers(false);
         List<ModelResult<FoundChoice>> found = ChoiceRecognizers.recognizeChoicesFromStrings(
             "one",
             colorChoices,
-            new FindChoicesOptions() {{ setRecognizeNumbers(false);}});
+            options);
         Assert.assertEquals(0, found.size());
     }
 

--- a/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/prompts/ActivityPromptTests.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/prompts/ActivityPromptTests.java
@@ -65,7 +65,8 @@ public class ActivityPromptTests {
         dialogs.add(eventPrompt);
 
         // Create mock Activity for testing.
-        Activity eventActivity = new Activity() { { setType(ActivityTypes.EVENT); setValue(2); }};
+        Activity eventActivity = new Activity(ActivityTypes.EVENT);
+        eventActivity.setValue(2);
 
         BotCallbackHandler botLogic = (turnContext -> {
             DialogContext dc =  dialogs.createContext(turnContext).join();

--- a/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/prompts/ChoicePromptTests.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/prompts/ChoicePromptTests.java
@@ -209,6 +209,19 @@ public class ChoicePromptTests {
 
         dialogs.add(listPrompt);
 
+        CardAction red = new CardAction();
+        red.setType(ActionTypes.IM_BACK);
+        red.setValue("red");
+        red.setTitle("red");
+        CardAction green = new CardAction();
+        green.setType(ActionTypes.IM_BACK);
+        green.setValue("green");
+        green.setTitle("green");
+        CardAction blue = new CardAction();
+        blue.setType(ActionTypes.IM_BACK);
+        blue.setValue("blue");
+        blue.setTitle("blue");
+        CardAction[] suggestedActions = new CardAction[] { red, green, blue };
         new TestFlow(adapter, (turnContext) -> {
             DialogContext dc =  dialogs.createContext(turnContext).join();
             DialogTurnResult results = dc.continueDialog().join();
@@ -222,31 +235,7 @@ public class ChoicePromptTests {
             return CompletableFuture.completedFuture(null);
             })
             .send("hello")
-            .assertReply(new Validators().validateSuggestedActions("favorite color?", new SuggestedActions(new
-            CardAction[]
-            {
-                new CardAction() {
-                    {
-                        setType(ActionTypes.IM_BACK);
-                        setValue("red");
-                        setTitle("red");
-                    }
-                },
-                new CardAction() {
-                    {
-                        setType(ActionTypes.IM_BACK);
-                        setValue("green");
-                        setTitle("green");
-                    }
-                },
-                new CardAction() {
-                    {
-                        setType(ActionTypes.IM_BACK);
-                        setValue("blue");
-                        setTitle("blue");
-                    }
-                }
-            })))
+            .assertReply(new Validators().validateSuggestedActions("favorite color?", new SuggestedActions(suggestedActions)))
             .startTest()
             .join();
     }
@@ -266,6 +255,26 @@ public class ChoicePromptTests {
 
         dialogs.add(listPrompt);
 
+        CardAction red = new CardAction();
+        red.setType(ActionTypes.IM_BACK);
+        red.setValue("red");
+        red.setTitle("red");
+        CardAction green = new CardAction();
+        green.setType(ActionTypes.IM_BACK);
+        green.setValue("green");
+        green.setTitle("green");
+        CardAction blue = new CardAction();
+        blue.setType(ActionTypes.IM_BACK);
+        blue.setValue("blue");
+        blue.setTitle("blue");
+        ArrayList<CardAction> buttons = new ArrayList<CardAction>();
+        buttons.add(red);
+        buttons.add(green);
+        buttons.add(blue);
+        HeroCard card = new HeroCard();
+        card.setText("favorite color?");
+        card.setButtons(buttons);
+
         new TestFlow(adapter, (turnContext) -> {
             DialogContext dc =  dialogs.createContext(turnContext).join();
             DialogTurnResult results = dc.continueDialog().join();
@@ -279,37 +288,7 @@ public class ChoicePromptTests {
             return CompletableFuture.completedFuture(null);
             })
             .send("hello")
-            .assertReply(new Validators().validateHeroCard(
-                new HeroCard() {
-                    {
-                        setText("favorite color?");
-                        setButtons(new ArrayList<CardAction>() {
-                            {
-                                add(new CardAction() {
-                                        {
-                                            setType(ActionTypes.IM_BACK);
-                                            setValue("red");
-                                            setTitle("red");
-                                        }
-                                    });
-                                    add(new CardAction() {
-                                        {
-                                            setType(ActionTypes.IM_BACK);
-                                            setValue("green");
-                                            setTitle("green");
-                                        }
-                                    });
-                                    add(new CardAction() {
-                                        {
-                                            setType(ActionTypes.IM_BACK);
-                                            setValue("blue");
-                                            setTitle("blue");
-                                        }
-                                    });
-                            }
-                        });
-                    }
-                }, 0))
+            .assertReply(new Validators().validateHeroCard(card, 0))
             .startTest().join();
     }
 
@@ -327,6 +306,26 @@ public class ChoicePromptTests {
         listPrompt.setStyle(ListStyle.HEROCARD);
 
         dialogs.add(listPrompt);
+        HeroCard card = new HeroCard();
+        card.setText("favorite color?");
+        CardAction red = new CardAction();
+        red.setType(ActionTypes.IM_BACK);
+        red.setValue("red");
+        red.setTitle("red");
+        CardAction green = new CardAction();
+        green.setType(ActionTypes.IM_BACK);
+        green.setValue("green");
+        green.setTitle("green");
+        CardAction blue = new CardAction();
+        blue.setType(ActionTypes.IM_BACK);
+        blue.setValue("blue");
+        blue.setTitle("blue");
+        ArrayList<CardAction> buttons = new ArrayList<CardAction>();
+        buttons.add(red);
+        buttons.add(green);
+        buttons.add(blue);
+        card.setButtons(buttons);
+
 
         new TestFlow(adapter, (turnContext) -> {
             DialogContext dc =  dialogs.createContext(turnContext).join();
@@ -347,37 +346,7 @@ public class ChoicePromptTests {
             return CompletableFuture.completedFuture(null);
             })
             .send("hello")
-            .assertReply(new Validators().validateHeroCard(
-                new HeroCard() {
-                    {
-                        setText("favorite color?");
-                        setButtons(new ArrayList<CardAction>() {
-                            {
-                                add(new CardAction() {
-                                        {
-                                            setType(ActionTypes.IM_BACK);
-                                            setValue("red");
-                                            setTitle("red");
-                                        }
-                                    });
-                                    add(new CardAction() {
-                                        {
-                                            setType(ActionTypes.IM_BACK);
-                                            setValue("green");
-                                            setTitle("green");
-                                        }
-                                    });
-                                    add(new CardAction() {
-                                        {
-                                            setType(ActionTypes.IM_BACK);
-                                            setValue("blue");
-                                            setTitle("blue");
-                                        }
-                                    });
-                            }
-                        });
-                    }
-                }, 1))
+            .assertReply(new Validators().validateHeroCard(card, 1))
             .startTest().join();
     }
 
@@ -580,6 +549,19 @@ public class ChoicePromptTests {
         listPrompt.setStyle(ListStyle.HEROCARD);
 
         dialogs.add(listPrompt);
+        CardAction red = new CardAction();
+        red.setType(ActionTypes.IM_BACK);
+        red.setValue("red");
+        red.setTitle("red");
+        CardAction green = new CardAction();
+        green.setType(ActionTypes.IM_BACK);
+        green.setValue("green");
+        green.setTitle("green");
+        CardAction blue = new CardAction();
+        blue.setType(ActionTypes.IM_BACK);
+        blue.setValue("blue");
+        blue.setTitle("blue");
+        CardAction[] suggestedActions = new CardAction[]{red, green, blue};
 
         new TestFlow(adapter, (turnContext) -> {
             DialogContext dc =  dialogs.createContext(turnContext).join();
@@ -595,31 +577,7 @@ public class ChoicePromptTests {
             return CompletableFuture.completedFuture(null);
         })
         .send("hello")
-        .assertReply(new Validators().validateSuggestedActions("favorite color?", new SuggestedActions(new
-        CardAction[]
-        {
-            new CardAction() {
-                {
-                    setType(ActionTypes.IM_BACK);
-                    setValue("red");
-                    setTitle("red");
-                }
-            },
-            new CardAction() {
-                {
-                    setType(ActionTypes.IM_BACK);
-                    setValue("green");
-                    setTitle("green");
-                }
-            },
-            new CardAction() {
-                {
-                    setType(ActionTypes.IM_BACK);
-                    setValue("blue");
-                    setTitle("blue");
-                }
-            }
-        })))
+        .assertReply(new Validators().validateSuggestedActions("favorite color?", new SuggestedActions(suggestedActions)))
         .startTest()
         .join();
     }
@@ -696,16 +654,13 @@ public class ChoicePromptTests {
         TestAdapter adapter = new TestAdapter().use(new AutoSaveStateMiddleware(convoState));
         // Create new DialogSet.
         DialogSet dialogs = new DialogSet(dialogState);
-        PromptCultureModel culture = new PromptCultureModel() {
-            {
-                setInlineOr(" customOr ");
-                setInlineOrMore(" customOrMore ");
-                setLocale("custom-custom");
-                setSeparator("customSeparator");
-                setNoInLanguage("customNo");
-                setYesInLanguage("customYes");
-            }
-        };
+        PromptCultureModel culture = new PromptCultureModel();
+        culture.setInlineOr(" customOr ");
+        culture.setInlineOrMore(" customOrMore ");
+        culture.setLocale("custom-custom");
+        culture.setSeparator("customSeparator");
+        culture.setNoInLanguage("customNo");
+        culture.setYesInLanguage("customYes");
 
         Map<String, ChoiceFactoryOptions> customDict = new HashMap<String, ChoiceFactoryOptions>();
         ChoiceFactoryOptions choiceOption = new ChoiceFactoryOptions(culture.getSeparator(),

--- a/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/prompts/NumberPromptTests.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/bot/dialogs/prompts/NumberPromptTests.java
@@ -566,6 +566,9 @@ public class NumberPromptTests {
         NumberPrompt<Double> numberPrompt = new NumberPrompt<Double>("NumberPrompt", null,
                                                     PromptCultureModels.DUTCH_CULTURE, Double.class);
         dialogs.add(numberPrompt);
+        Activity activityToSend = new Activity(ActivityTypes.MESSAGE);
+        activityToSend.setText("3,14");
+        activityToSend.setLocale(PromptCultureModels.DUTCH_CULTURE);
         new TestFlow(adapter, (turnContext) -> {
             DialogContext dc =  dialogs.createContext(turnContext).join();
             DialogTurnResult results = dc.continueDialog().join();
@@ -584,13 +587,7 @@ public class NumberPromptTests {
         })
         .send("hello")
         .assertReply("Enter a number.")
-        .send(new Activity() {
-                {
-                    setType(ActivityTypes.MESSAGE);
-                    setText("3,14");
-                    setLocale(PromptCultureModels.DUTCH_CULTURE);
-                }
-            })
+        .send(activityToSend)
         .startTest()
         .join();
     }

--- a/libraries/bot-integration-core/src/main/java/com/microsoft/bot/integration/AdapterWithErrorHandler.java
+++ b/libraries/bot-integration-core/src/main/java/com/microsoft/bot/integration/AdapterWithErrorHandler.java
@@ -94,14 +94,11 @@ public class AdapterWithErrorHandler extends BotFrameworkHttpAdapter {
         Throwable exception
     ) {
         if (StringUtils.equals(turnContext.getActivity().getChannelId(), Channels.EMULATOR)) {
-            Activity traceActivity = new Activity(ActivityTypes.TRACE) {
-                {
-                    setLabel("TurnError");
-                    setName("OnTurnError Trace");
-                    setValue(ExceptionUtils.getStackTrace(exception));
-                    setValueType("https://www.botframework.com/schemas/error");
-                }
-            };
+            Activity traceActivity = new Activity(ActivityTypes.TRACE);
+            traceActivity.setLabel("TurnError");
+            traceActivity.setName("OnTurnError Trace");
+            traceActivity.setValue(ExceptionUtils.getStackTrace(exception));
+            traceActivity.setValueType("https://www.botframework.com/schemas/error");
 
             return turnContext.sendActivity(traceActivity).thenApply(resourceResponse -> null);
         }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
@@ -253,20 +253,16 @@ public class Activity {
         Object withValue,
         String withLabel
     ) {
-        return new Activity(ActivityTypes.TRACE) {
-            {
-                setName(withName);
-                setLabel(withLabel);
-                if (withValue != null) {
-                    setValueType(
-                        (withValueType == null) ? withValue.getClass().getTypeName() : withValueType
-                    );
-                } else {
-                    setValueType(withValueType);
-                }
-                setValue(withValue);
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.TRACE);
+        activity.setName(withName);
+        activity.setLabel(withLabel);
+        if (withValue != null) {
+            activity.setValueType((withValueType == null) ? withValue.getClass().getTypeName() : withValueType);
+        } else {
+            activity.setValueType(withValueType);
+        }
+        activity.setValue(withValue);
+        return activity;
     }
 
     /**
@@ -296,12 +292,10 @@ public class Activity {
      * @return A conversation update type Activity.
      */
     public static Activity createConversationUpdateActivity() {
-        return new Activity(ActivityTypes.CONVERSATION_UPDATE) {
-            {
-                setMembersAdded(new ArrayList<>());
-                setMembersRemoved(new ArrayList<>());
-            }
-        };
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE);
+        activity.setMembersAdded(new ArrayList<>());
+        activity.setMembersRemoved(new ArrayList<>());
+        return activity;
     }
 
     /**
@@ -356,62 +350,58 @@ public class Activity {
      * @return new cloned activity
      */
     public static Activity clone(Activity activity) {
-        Activity clone = new Activity(activity.getType()) {
-            {
-                setId(activity.getId());
-                setTimestamp(activity.getTimestamp());
-                setLocalTimestamp(activity.getLocalTimestamp());
-                setLocalTimeZone(activity.getLocalTimezone());
-                setChannelData(activity.getChannelData());
-                setFrom(ChannelAccount.clone(activity.getFrom()));
-                setRecipient(ChannelAccount.clone(activity.getRecipient()));
-                setConversation(ConversationAccount.clone(activity.getConversation()));
-                setChannelId(activity.getChannelId());
-                setServiceUrl(activity.getServiceUrl());
-                setChannelId(activity.getChannelId());
-                setEntities(Entity.cloneList(activity.getEntities()));
-                setReplyToId(activity.getReplyToId());
-                setSpeak(activity.getSpeak());
-                setText(activity.getText());
-                setInputHint(activity.getInputHint());
-                setSummary(activity.getSummary());
-                setSuggestedActions(SuggestedActions.clone(activity.getSuggestedActions()));
-                setAttachments(Attachment.cloneList(activity.getAttachments()));
-                setAction(activity.getAction());
-                setLabel(activity.getLabel());
-                setValueType(activity.getValueType());
-                setValue(activity.getValue());
-                setName(activity.getName());
-                setRelatesTo(ConversationReference.clone(activity.getRelatesTo()));
-                setCode(activity.getCode());
-                setExpiration(activity.getExpiration());
-                setImportance(activity.getImportance());
-                setDeliveryMode(activity.getDeliveryMode());
-                setTextHighlights(activity.getTextHighlights());
-                setCallerId(activity.getCallerId());
-                setHistoryDisclosed(activity.getHistoryDisclosed());
-                setLocale(activity.getLocale());
-                setReactionsAdded(MessageReaction.cloneList(activity.getReactionsAdded()));
-                setReactionsRemoved(MessageReaction.cloneList(activity.getReactionsRemoved()));
-                setExpiration(activity.getExpiration());
-                setMembersAdded(ChannelAccount.cloneList(activity.getMembersAdded()));
-                setMembersRemoved(ChannelAccount.cloneList(activity.getMembersRemoved()));
-                setTextFormat(activity.getTextFormat());
-                setAttachmentLayout(activity.getAttachmentLayout());
-                setTopicName(activity.getTopicName());
-                if (activity.getListenFor() != null) {
-                    setListenFor(new ArrayList<>(activity.getListenFor()));
-                }
-            }
-        };
-
+        Activity cloned = new Activity(activity.getType());
+        cloned.setId(activity.getId());
+        cloned.setTimestamp(activity.getTimestamp());
+        cloned.setLocalTimestamp(activity.getLocalTimestamp());
+        cloned.setLocalTimeZone(activity.getLocalTimezone());
+        cloned.setChannelData(activity.getChannelData());
+        cloned.setFrom(ChannelAccount.clone(activity.getFrom()));
+        cloned.setRecipient(ChannelAccount.clone(activity.getRecipient()));
+        cloned.setConversation(ConversationAccount.clone(activity.getConversation()));
+        cloned.setChannelId(activity.getChannelId());
+        cloned.setServiceUrl(activity.getServiceUrl());
+        cloned.setChannelId(activity.getChannelId());
+        cloned.setEntities(Entity.cloneList(activity.getEntities()));
+        cloned.setReplyToId(activity.getReplyToId());
+        cloned.setSpeak(activity.getSpeak());
+        cloned.setText(activity.getText());
+        cloned.setInputHint(activity.getInputHint());
+        cloned.setSummary(activity.getSummary());
+        cloned.setSuggestedActions(SuggestedActions.clone(activity.getSuggestedActions()));
+        cloned.setAttachments(Attachment.cloneList(activity.getAttachments()));
+        cloned.setAction(activity.getAction());
+        cloned.setLabel(activity.getLabel());
+        cloned.setValueType(activity.getValueType());
+        cloned.setValue(activity.getValue());
+        cloned.setName(activity.getName());
+        cloned.setRelatesTo(ConversationReference.clone(activity.getRelatesTo()));
+        cloned.setCode(activity.getCode());
+        cloned.setExpiration(activity.getExpiration());
+        cloned.setImportance(activity.getImportance());
+        cloned.setDeliveryMode(activity.getDeliveryMode());
+        cloned.setTextHighlights(activity.getTextHighlights());
+        cloned.setCallerId(activity.getCallerId());
+        cloned.setHistoryDisclosed(activity.getHistoryDisclosed());
+        cloned.setLocale(activity.getLocale());
+        cloned.setReactionsAdded(MessageReaction.cloneList(activity.getReactionsAdded()));
+        cloned.setReactionsRemoved(MessageReaction.cloneList(activity.getReactionsRemoved()));
+        cloned.setExpiration(activity.getExpiration());
+        cloned.setMembersAdded(ChannelAccount.cloneList(activity.getMembersAdded()));
+        cloned.setMembersRemoved(ChannelAccount.cloneList(activity.getMembersRemoved()));
+        cloned.setTextFormat(activity.getTextFormat());
+        cloned.setAttachmentLayout(activity.getAttachmentLayout());
+        cloned.setTopicName(activity.getTopicName());
+        if (activity.getListenFor() != null) {
+            cloned.setListenFor(new ArrayList<>(activity.getListenFor()));
+        }
         for (Map.Entry<String, JsonNode> entry : activity.getProperties().entrySet()) {
-            clone.setProperties(entry.getKey(), entry.getValue());
+            cloned.setProperties(entry.getKey(), entry.getValue());
         }
 
-        clone = ensureActivityHasId(clone);
+        cloned = ensureActivityHasId(cloned);
 
-        return clone;
+        return cloned;
     }
 
     private static Activity ensureActivityHasId(Activity activity) {
@@ -1525,17 +1515,15 @@ public class Activity {
      */
     @JsonIgnore
     public ConversationReference getConversationReference() {
-        return new ConversationReference() {
-            {
-                setActivityId(Activity.this.getId());
-                setUser(Activity.this.getFrom());
-                setBot(Activity.this.getRecipient());
-                setConversation(Activity.this.getConversation());
-                setChannelId(Activity.this.getChannelId());
-                setLocale(Activity.this.getLocale());
-                setServiceUrl(Activity.this.getServiceUrl());
-            }
-        };
+        ConversationReference conversationReference = new ConversationReference();
+        conversationReference.setActivityId(getId());
+        conversationReference.setUser(getFrom());
+        conversationReference.setBot(getRecipient());
+        conversationReference.setConversation(getConversation());
+        conversationReference.setChannelId(getChannelId());
+        conversationReference.setLocale(getLocale());
+        conversationReference.setServiceUrl(getServiceUrl());
+        return conversationReference;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/AnimationCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/AnimationCard.java
@@ -344,11 +344,9 @@ public class AnimationCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(AnimationCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+        return attachment;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Attachment.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Attachment.java
@@ -70,19 +70,17 @@ public class Attachment {
             return null;
         }
 
-        return new Attachment() {
-            {
-                setContentType(attachment.getContentType());
-                setContent(attachment.getContent());
-                setContentUrl(attachment.getContentUrl());
-                setName(attachment.getName());
-                setThumbnailUrl(attachment.getThumbnailUrl());
+        Attachment cloned = new Attachment();
+        cloned.setContentType(attachment.getContentType());
+        cloned.setContent(attachment.getContent());
+        cloned.setContentUrl(attachment.getContentUrl());
+        cloned.setName(attachment.getName());
+        cloned.setThumbnailUrl(attachment.getThumbnailUrl());
 
-                for (String key : attachment.getProperties().keySet()) {
-                    this.setProperties(key, attachment.getProperties().get(key));
-                }
-            }
-        };
+        for (String key : attachment.getProperties().keySet()) {
+            cloned.setProperties(key, attachment.getProperties().get(key));
+        }
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/AudioCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/AudioCard.java
@@ -345,11 +345,9 @@ public class AudioCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(AudioCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+        return attachment;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/CardAction.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/CardAction.java
@@ -80,18 +80,17 @@ public class CardAction {
             return null;
         }
 
-        return new CardAction() {
-            {
-                setValue(cardAction.getValue());
-                setTitle(cardAction.getTitle());
-                setDisplayText(cardAction.getDisplayText());
-                setImage(cardAction.getImage());
-                setType(cardAction.getType());
-                setText(cardAction.getText());
-                setChannelData(cardAction.getChannelData());
-                setImageAltText(cardAction.getImageAltText());
-            }
-        };
+        CardAction cloned = new CardAction();
+        cloned.setValue(cardAction.getValue());
+        cloned.setTitle(cardAction.getTitle());
+        cloned.setDisplayText(cardAction.getDisplayText());
+        cloned.setImage(cardAction.getImage());
+        cloned.setType(cardAction.getType());
+        cloned.setText(cardAction.getText());
+        cloned.setChannelData(cardAction.getChannelData());
+        cloned.setImageAltText(cardAction.getImageAltText());
+
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ChannelAccount.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ChannelAccount.java
@@ -52,18 +52,17 @@ public class ChannelAccount {
             return null;
         }
 
-        return new ChannelAccount() {
-            {
-                setId(channelAccount.getId());
-                setRole(channelAccount.getRole());
-                setName(channelAccount.getName());
-                setAadObjectId(channelAccount.getAadObjectId());
+        ChannelAccount cloned = new ChannelAccount();
+        cloned.setId(channelAccount.getId());
+        cloned.setRole(channelAccount.getRole());
+        cloned.setName(channelAccount.getName());
+        cloned.setAadObjectId(channelAccount.getAadObjectId());
 
-                for (String key : channelAccount.getProperties().keySet()) {
-                    this.setProperties(key, channelAccount.getProperties().get(key));
-                }
-            }
-        };
+        for (String key : channelAccount.getProperties().keySet()) {
+            cloned.setProperties(key, channelAccount.getProperties().get(key));
+        }
+
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ConversationAccount.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ConversationAccount.java
@@ -278,21 +278,19 @@ public class ConversationAccount {
             return null;
         }
 
-        return new ConversationAccount() {
-            {
-                setId(conversationAccount.getId());
-                setName(conversationAccount.getName());
-                setIsGroup(conversationAccount.isGroup());
-                setConversationType(conversationAccount.getConversationType());
-                setAadObjectId(conversationAccount.getAadObjectId());
-                setRole(conversationAccount.getRole());
-                setAadObjectId(conversationAccount.getAadObjectId());
+        ConversationAccount cloned = new ConversationAccount();
+        cloned.setId(conversationAccount.getId());
+        cloned.setName(conversationAccount.getName());
+        cloned.setIsGroup(conversationAccount.isGroup());
+        cloned.setConversationType(conversationAccount.getConversationType());
+        cloned.setAadObjectId(conversationAccount.getAadObjectId());
+        cloned.setRole(conversationAccount.getRole());
+        cloned.setAadObjectId(conversationAccount.getAadObjectId());
+        for (String key : conversationAccount.getProperties().keySet()) {
+            cloned.setProperties(key, conversationAccount.getProperties().get(key));
+        }
 
-                for (String key : conversationAccount.getProperties().keySet()) {
-                    this.setProperties(key, conversationAccount.getProperties().get(key));
-                }
-            }
-        };
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ConversationReference.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ConversationReference.java
@@ -52,17 +52,16 @@ public class ConversationReference {
             return null;
         }
 
-        return new ConversationReference() {
-            {
-                setActivityId(conversationReference.getActivityId());
-                setBot(ChannelAccount.clone(conversationReference.getBot()));
-                setUser(ChannelAccount.clone(conversationReference.getUser()));
-                setConversation(ConversationAccount.clone(conversationReference.getConversation()));
-                setServiceUrl(conversationReference.getServiceUrl());
-                setLocale(conversationReference.getLocale());
-                setChannelId(conversationReference.getChannelId());
-            }
-        };
+        ConversationReference cloned = new ConversationReference();
+        cloned.setActivityId(conversationReference.getActivityId());
+        cloned.setBot(ChannelAccount.clone(conversationReference.getBot()));
+        cloned.setUser(ChannelAccount.clone(conversationReference.getUser()));
+        cloned.setConversation(ConversationAccount.clone(conversationReference.getConversation()));
+        cloned.setServiceUrl(conversationReference.getServiceUrl());
+        cloned.setLocale(conversationReference.getLocale());
+        cloned.setChannelId(conversationReference.getChannelId());
+
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Entity.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Entity.java
@@ -47,15 +47,13 @@ public class Entity implements EntitySerialization {
             return null;
         }
 
-        return new Entity() {
-            {
-                setType(entity.getType());
+        Entity cloned = new Entity();
+        cloned.setType(entity.getType());
+        for (String key : entity.getProperties().keySet()) {
+            cloned.setProperties(key, entity.getProperties().get(key));
+        }
 
-                for (String key : entity.getProperties().keySet()) {
-                    setProperties(key, entity.getProperties().get(key));
-                }
-            }
-        };
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/HeroCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/HeroCard.java
@@ -191,11 +191,9 @@ public class HeroCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(HeroCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+        return attachment;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/MessageReaction.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/MessageReaction.java
@@ -31,12 +31,9 @@ public class MessageReaction {
         if (messageReaction == null) {
             return null;
         }
-
-        return new MessageReaction() {
-            {
-                setType(messageReaction.getType());
-            }
-        };
+        MessageReaction cloned = new MessageReaction();
+        cloned.setType(messageReaction.getType());
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/OAuthCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/OAuthCard.java
@@ -112,12 +112,11 @@ public class OAuthCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(OAuthCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+
+        return attachment;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ReceiptCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ReceiptCard.java
@@ -250,11 +250,9 @@ public class ReceiptCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(ReceiptCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+        return attachment;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/SigninCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/SigninCard.java
@@ -82,11 +82,9 @@ public class SigninCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(SigninCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+        return attachment;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/SuggestedActions.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/SuggestedActions.java
@@ -41,17 +41,16 @@ public class SuggestedActions {
             return null;
         }
 
-        return new SuggestedActions() {
-            {
-                setTo(suggestedActions.getTo());
+        SuggestedActions cloned = new SuggestedActions();
+        cloned.setTo(suggestedActions.getTo());
 
-                List<CardAction> cloned = suggestedActions.getActions()
-                    .stream()
-                    .map(card -> CardAction.clone(card))
-                    .collect(Collectors.toCollection(ArrayList::new));
-                setActions(cloned);
-            }
-        };
+        List<CardAction> actions = suggestedActions.getActions()
+            .stream()
+            .map(card -> CardAction.clone(card))
+            .collect(Collectors.toCollection(ArrayList::new));
+        cloned.setActions(actions);
+
+        return cloned;
     }
 
     /**

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ThumbnailCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/ThumbnailCard.java
@@ -182,11 +182,9 @@ public class ThumbnailCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(ThumbnailCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+        return attachment;
     }
 }

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/VideoCard.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/VideoCard.java
@@ -310,11 +310,9 @@ public class VideoCard {
      * @return An Attachment object containing the card.
      */
     public Attachment toAttachment() {
-        return new Attachment() {
-            {
-                setContent(VideoCard.this);
-                setContentType(CONTENTTYPE);
-            }
-        };
+        Attachment attachment = new Attachment();
+        attachment.setContent(this);
+        attachment.setContentType(CONTENTTYPE);
+        return attachment;
     }
 }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
@@ -34,11 +34,8 @@ public class ActivityTest {
     public void GetReplyConversationReference() {
         Activity activity = createActivity();
 
-        ResourceResponse reply = new ResourceResponse() {
-            {
-                setId("1234");
-            }
-        };
+        ResourceResponse reply = new ResourceResponse();
+        reply.setId("1234");
 
         ConversationReference conversationReference = activity.getReplyConversationReference(reply);
 
@@ -55,30 +52,22 @@ public class ActivityTest {
     public void ApplyConversationReference_isIncoming() {
         Activity activity = createActivity();
 
-        ConversationReference conversationReference = new ConversationReference() {
-            {
-                setChannelId("cr_123");
-                setServiceUrl("cr_serviceUrl");
-                setConversation(new ConversationAccount() {
-                    {
-                        setId("cr_456");
-                    }
-                });
-                setUser(new ChannelAccount() {
-                    {
-                        setId("cr_abc");
-                    }
-                });
-                setBot(new ChannelAccount() {
-                    {
-                        setId("cr_def");
-                    }
-                });
-                setActivityId("cr_12345");
-                setLocale("en-uS"); // Intentionally oddly-cased to check that it isn't defaulted somewhere, but
-                                    // tests stay in English
-            }
-        };
+        ConversationReference conversationReference = new ConversationReference();
+        conversationReference.setChannelId("cr_123");
+        conversationReference.setServiceUrl("cr_serviceUrl");
+        ConversationAccount conversation = new ConversationAccount();
+        conversation.setId("cr_456");
+        conversationReference.setConversation(conversation);
+        ChannelAccount userAccount = new ChannelAccount();
+        userAccount.setId("cr_abc");
+        conversationReference.setUser(userAccount);
+        ChannelAccount botAccount = new ChannelAccount();
+        botAccount.setId("cr_def");
+        conversationReference.setBot(botAccount);
+        conversationReference.setActivityId("cr_12345");
+        // Intentionally oddly-cased to check that it isn't defaulted somewhere, but
+        // tests stay in English
+        conversationReference.setLocale("en-uS");
 
         activity.applyConversationReference(conversationReference, true);
 
@@ -96,30 +85,22 @@ public class ActivityTest {
     public void ApplyConversationReference() {
         Activity activity = createActivity();
 
-        ConversationReference conversationReference = new ConversationReference() {
-            {
-                setChannelId("123");
-                setServiceUrl("serviceUrl");
-                setConversation(new ConversationAccount() {
-                    {
-                        setId("456");
-                    }
-                });
-                setUser(new ChannelAccount() {
-                    {
-                        setId("abc");
-                    }
-                });
-                setBot(new ChannelAccount() {
-                    {
-                        setId("def");
-                    }
-                });
-                setActivityId("12345");
-                setLocale("en-uS"); // Intentionally oddly-cased to check that it isn't defaulted somewhere, but
-                                    // tests stay in English
-            }
-        };
+        ConversationReference conversationReference = new ConversationReference();
+        conversationReference.setChannelId("123");
+        conversationReference.setServiceUrl("serviceUrl");
+        ConversationAccount conversation = new ConversationAccount();
+        conversation.setId("456");
+        conversationReference.setConversation(conversation);
+        ChannelAccount userAccount = new ChannelAccount();
+        userAccount.setId("abc");
+        conversationReference.setUser(userAccount);
+        ChannelAccount botAccount = new ChannelAccount();
+        botAccount.setId("def");
+        conversationReference.setBot(botAccount);
+        conversationReference.setActivityId("12345");
+        // Intentionally oddly-cased to check that it isn't defaulted somewhere, but
+        // tests stay in English
+        conversationReference.setLocale("en-uS");
 
         activity.applyConversationReference(conversationReference, false);
 
@@ -143,46 +124,35 @@ public class ActivityTest {
     }
 
     private Activity createActivity() {
-        ChannelAccount account1 = new ChannelAccount() {
-            {
-                setId("ChannelAccount_Id_1");
-                setName("ChannelAccount_Name_1");
-                setProperties("Name", JsonNodeFactory.instance.objectNode().put("Name", "Value"));
-                setRole(RoleTypes.USER);
-            }
-        };
+        ChannelAccount account1 = new ChannelAccount();
+        account1.setId("ChannelAccount_Id_1");
+        account1.setName("ChannelAccount_Name_1");
+        account1.setProperties("Name", JsonNodeFactory.instance.objectNode().put("Name", "Value"));
+        account1.setRole(RoleTypes.USER);
 
-        ChannelAccount account2 = new ChannelAccount() {
-            {
-                setId("ChannelAccount_Id_2");
-                setName("ChannelAccount_Name_2");
-                setProperties("Name", JsonNodeFactory.instance.objectNode().put("Name", "Value"));
-                setRole(RoleTypes.USER);
-            }
-        };
+        ChannelAccount account2 = new ChannelAccount();
+        account2.setId("ChannelAccount_Id_2");
+        account2.setName("ChannelAccount_Name_2");
+        account2.setProperties("Name", JsonNodeFactory.instance.objectNode().put("Name", "Value"));
+        account2.setRole(RoleTypes.USER);
 
-        ConversationAccount conversationAccount = new ConversationAccount() {
-            {
-                setConversationType("a");
-                setId("123");
-                setIsGroup(true);
-                setName("Name");
-                setProperties("Name", JsonNodeFactory.instance.objectNode().put("Name", "Value"));
-            }
-        };
+        ConversationAccount conversationAccount = new ConversationAccount();
+        conversationAccount.setConversationType("a");
+        conversationAccount.setId("123");
+        conversationAccount.setIsGroup(true);
+        conversationAccount.setName("Name");
+        conversationAccount.setProperties("Name", JsonNodeFactory.instance.objectNode().put("Name", "Value"));
 
-        Activity activity = new Activity() {
-            {
-                setId("123");
-                setFrom(account1);
-                setRecipient(account2);
-                setConversation(conversationAccount);
-                setChannelId("ChannelId123");
-                setLocale("en-uS"); // Intentionally oddly-cased to check that it isn't defaulted somewhere, but
-                                    // tests stay in English
-                setServiceUrl("ServiceUrl123");
-            }
-        };
+        Activity activity = new Activity();
+        activity.setId("123");
+        activity.setFrom(account1);
+        activity.setRecipient(account2);
+        activity.setConversation(conversationAccount);
+        activity.setChannelId("ChannelId123");
+        // Intentionally oddly-cased to check that it isn't defaulted somewhere, but
+        // tests stay in English
+        activity.setLocale("en-uS");
+        activity.setServiceUrl("ServiceUrl123");
 
         return activity;
     }
@@ -470,16 +440,12 @@ public class ActivityTest {
     public void GetMentions() {
         ArrayList<Entity> mentions = new ArrayList<Entity>();
 
-        mentions.add(new Entity() {
-            {
-                setType("mention");
-            }
-        });
-        mentions.add(new Entity() {
-            {
-                setType("reaction");
-            }
-        });
+        Entity mentionEntity = new Entity();
+        mentionEntity.setType("mention");
+        mentions.add(mentionEntity);
+        Entity reactionEntity = new Entity();
+        reactionEntity.setType("reaction");
+        mentions.add(reactionEntity);
 
         Activity activity = createActivity();
 

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AnimationCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AnimationCardTest.java
@@ -13,19 +13,20 @@ import org.junit.Test;
 public class AnimationCardTest {
     ArrayList<MediaUrl> media = new ArrayList<MediaUrl>();
 
-    AnimationCard card = new AnimationCard(){
-        {
-            setText("Test Animation Text");
-            setMedia(media);
-        }
-    };
+    AnimationCard getCard() {
+        AnimationCard card = new AnimationCard();
+        card.setText("Test Animation Text");
+        card.setMedia(media);
+        return card;
+    }
+
 
     /**
      *Ensures that the AnimationCard can be used as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.animation", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AudioCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/AudioCardTest.java
@@ -13,19 +13,19 @@ import org.junit.Test;
 public class AudioCardTest {
     ArrayList<MediaUrl> media = new ArrayList<MediaUrl>();
 
-    AudioCard card = new AudioCard(){
-        {
-            setText("Test Audio Text");
-            setMedia(media);
-        };
-    };
+    AudioCard getCard() {
+        AudioCard card = new AudioCard();
+        card.setText("Test Audio Text");
+        card.setMedia(media);
+        return card;
+    }
 
     /**
      *Ensures that the AudioCard can be used as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.audio", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/EntitySchemaValidationTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/EntitySchemaValidationTest.java
@@ -12,12 +12,9 @@ import org.junit.Test;
 public class EntitySchemaValidationTest {
     @Test
     public void EntityTests_GeoCoordinatesSerializationDeserializationTest() {
-        GeoCoordinates geoCoordinates = new GeoCoordinates() {
-            {
-                setLatitude(22.00);
-                setLongitude(23.00);
-            }
-        };
+        GeoCoordinates geoCoordinates = new GeoCoordinates();
+        geoCoordinates.setLatitude(22.00);
+        geoCoordinates.setLongitude(23.00);
 
         Assert.assertEquals("GeoCoordinates", geoCoordinates.getType());
 
@@ -36,11 +33,8 @@ public class EntitySchemaValidationTest {
 
     @Test
     public void EntityTests_MentionSerializationDeserializationTest() {
-        Mention mentionEntity = new Mention() {
-            {
-                setText("TESTTEST");
-            }
-        };
+        Mention mentionEntity = new Mention();
+        mentionEntity.setText("TESTTEST");
 
         Assert.assertEquals("mention", mentionEntity.getType());
 
@@ -59,11 +53,8 @@ public class EntitySchemaValidationTest {
 
     @Test
     public void EntityTests_PlaceSerializationDeserializationTest() {
-        Place placeEntity = new Place() {
-            {
-                setName("TESTTEST");
-            }
-        };
+        Place placeEntity = new Place();
+        placeEntity.setName("TESTTEST");
 
         Assert.assertEquals("Place", placeEntity.getType());
 

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/HeroCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/HeroCardTest.java
@@ -10,20 +10,20 @@ import org.junit.Test;
  * Tests to ensure the HeroCard methods work as expected.
  */
 public class HeroCardTest {
-    HeroCard card = new HeroCard(){
-        {
-            setTitle("Hero Card Title");
-            setSubtitle("Hero Card Subtitle");
-            setText("Testing Text.");
-        }
-    };
+    HeroCard getCard() {
+        HeroCard card = new HeroCard();
+        card.setTitle("Hero Card Title");
+        card.setSubtitle("Hero Card Subtitle");
+        card.setText("Testing Text.");
+        return card;
+    }
 
     /**
      * Ensures that the HeroCard can be added as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.hero", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/OAuthCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/OAuthCardTest.java
@@ -10,19 +10,19 @@ import org.junit.Test;
  * Tests to ensure the OAuthCard methods work as expected.
  */
 public class OAuthCardTest {
-    OAuthCard card = new OAuthCard(){
-        {
-            setText("Test OAuth Text");
-            setConnectionName("Test Connection Name");
-        }
-    };
+    OAuthCard getCard() {
+        OAuthCard card = new OAuthCard();
+        card.setText("Test OAuth Text");
+        card.setConnectionName("Test Connection Name");
+        return card;
+    }
 
     /**
      *Ensures that the OAuthCard can be used as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.oauth", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ReceiptCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ReceiptCardTest.java
@@ -11,18 +11,18 @@ import org.junit.Test;
  */
 public class ReceiptCardTest {
 
-    ReceiptCard card = new ReceiptCard() {
-        {
-            setTitle("John Doe");
-        }
-    };
+    ReceiptCard getCard() {
+        ReceiptCard card = new ReceiptCard();
+        card.setTitle("John Doe");
+        return card;
+    }
 
     /**
      * Ensures that the ReceiptCard can be added as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.receipt", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/SigninCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/SigninCardTest.java
@@ -10,18 +10,18 @@ import org.junit.Test;
  * Tests to ensure the SigninCard methods work as expected.
  */
 public class SigninCardTest {
-    SigninCard card = new SigninCard(){
-        {
-            setText("Test Signin Text");
-        }
-    };
+    SigninCard getCard() {
+        SigninCard card = new SigninCard();
+        card.setText("Test Signin Text");
+        return card;
+    }
 
     /**
      *Ensures that the SigninCard can be used as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.signin", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ThumbnailCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ThumbnailCardTest.java
@@ -10,22 +10,22 @@ import org.junit.Test;
  * Tests to ensure the ThumbnailCard methods work as expected.
  */
 public class ThumbnailCardTest {
-    ThumbnailCard card = new ThumbnailCard(){
-        {
-            setText("Test Thumbnail Text");
-            setTitle("Test Thumbnail Title");
-            setSubtitle("Test Thumbnail Subtitle");
-            setImage(new CardImage());
-            setTap(new CardAction());
-        }
-    };
+    ThumbnailCard getCard() {
+        ThumbnailCard card = new ThumbnailCard();
+        card.setText("Test Thumbnail Text");
+        card.setTitle("Test Thumbnail Title");
+        card.setSubtitle("Test Thumbnail Subtitle");
+        card.setImage(new CardImage());
+        card.setTap(new CardAction());
+        return card;
+    }
 
     /**
      *Ensures that the ThumbnailCard can be used as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.thumbnail", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/VideoCardTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/VideoCardTest.java
@@ -10,21 +10,21 @@ import org.junit.Test;
  * Tests to ensure the VideoCard methods work as expected.
  */
 public class VideoCardTest {
-    VideoCard card = new VideoCard(){
-        {
-            setTitle("Test Video Title");
-            setSubtitle("Test Video Subtitle");
-            setText("Test Video Text");
-            setImage(new ThumbnailUrl());
-        }
-    };
+    VideoCard getCard() {
+        VideoCard card = new VideoCard();
+        card.setTitle("Test Video Title");
+        card.setSubtitle("Test Video Subtitle");
+        card.setText("Test Video Text");
+        card.setImage(new ThumbnailUrl());
+        return card;
+    }
 
     /**
      *Ensures that the VideoCard can be used as an attachment.
      */
     @Test
     public void testToAttachment() {
-        Attachment attachment = card.toAttachment();
+        Attachment attachment = getCard().toAttachment();
         Assert.assertNotNull(attachment);
         Assert.assertEquals("application/vnd.microsoft.card.video", attachment.getContentType());
     }

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/teams/MessageActionsPayloadTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/teams/MessageActionsPayloadTest.java
@@ -28,11 +28,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetId(){
         String id = "testId";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setId(id);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setId(id);
         String result = messageActionsPayload.getId();
 
         Assert.assertEquals(result, id);
@@ -44,11 +41,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetReplyToId(){
         String replyToId = "testReplyToId";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setReplyToId(replyToId);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setReplyToId(replyToId);
         String result = messageActionsPayload.getReplyToId();
 
         Assert.assertEquals(result, replyToId);
@@ -60,11 +54,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetMessageType(){
         String messageType = "testMessageType";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setMessageType(messageType);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setMessageType(messageType);
         String result = messageActionsPayload.getMessageType();
 
         Assert.assertEquals(result, messageType);
@@ -76,11 +67,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetCreatedDateTime(){
         String createdDateTime = "2000-01-01";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setCreatedDateTime(createdDateTime);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setCreatedDateTime(createdDateTime);
         String result = messageActionsPayload.getCreatedDateTime();
 
         Assert.assertEquals(result, createdDateTime);
@@ -92,11 +80,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetLastModifiedDateTime(){
         String lastModifiedDateTime = "2000-01-01";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setLastModifiedDateTime(lastModifiedDateTime);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setLastModifiedDateTime(lastModifiedDateTime);
         String result = messageActionsPayload.getLastModifiedDateTime();
 
         Assert.assertEquals(result, lastModifiedDateTime);
@@ -108,11 +93,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetDeleted(){
         Boolean deleted = false;
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setDeleted(deleted);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setDeleted(deleted);
         Boolean result = messageActionsPayload.getDeleted();
 
         Assert.assertEquals(result, deleted);
@@ -124,11 +106,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetSubject(){
         String subject = "testSubject";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setSubject(subject);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setSubject(subject);
         String result = messageActionsPayload.getSubject();
 
         Assert.assertEquals(result, subject);
@@ -140,11 +119,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetSummary(){
         String summary = "testSummary";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setSummary(summary);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setSummary(summary);
         String result = messageActionsPayload.getSummary();
 
         Assert.assertEquals(result, summary);
@@ -156,11 +132,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetImportance(){
         String importance = "normal";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setImportance(importance);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setImportance(importance);
         String result = messageActionsPayload.getImportance();
 
         Assert.assertEquals(result, importance);
@@ -172,11 +145,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetLinkToMessage(){
         String linkToMessage = "https://teams.microsoft.com/l/message/testing-id";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setLinkToMessage(linkToMessage);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setLinkToMessage(linkToMessage);
         String result = messageActionsPayload.getLinkToMessage();
 
         Assert.assertEquals(result, linkToMessage);
@@ -188,11 +158,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetLocale(){
         String locale = "US";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setLocale(locale);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setLocale(locale);
         String result = messageActionsPayload.getLocale();
 
         Assert.assertEquals(result, locale);
@@ -204,11 +171,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetFrom(){
         MessageActionsPayloadFrom from = new MessageActionsPayloadFrom();
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setFrom(from);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setFrom(from);
         MessageActionsPayloadFrom result = messageActionsPayload.getFrom();
 
         Assert.assertEquals(result, from);
@@ -220,11 +184,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetBody(){
         MessageActionsPayloadBody body = new MessageActionsPayloadBody();
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setBody(body);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setBody(body);
         MessageActionsPayloadBody result = messageActionsPayload.getBody();
 
         Assert.assertEquals(result, body);
@@ -236,11 +197,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetAttachmentLayout(){
         String attachmentLayout = "testAttachmentLayout";
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setAttachmentLayout(attachmentLayout);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setAttachmentLayout(attachmentLayout);
         String result = messageActionsPayload.getAttachmentLayout();
 
         Assert.assertEquals(result, attachmentLayout);
@@ -252,11 +210,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetAttachments(){
         List<MessageActionsPayloadAttachment> attachments = new ArrayList<MessageActionsPayloadAttachment>();
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setAttachments(attachments);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setAttachments(attachments);
         List<MessageActionsPayloadAttachment> result = messageActionsPayload.getAttachments();
 
         Assert.assertEquals(result, attachments);
@@ -268,11 +223,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetMentions(){
         List<MessageActionsPayloadMention> mentions = new ArrayList<MessageActionsPayloadMention>();
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setMentions(mentions);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setMentions(mentions);
         List<MessageActionsPayloadMention> result = messageActionsPayload.getMentions();
 
         Assert.assertEquals(result, mentions);
@@ -284,11 +236,8 @@ public class MessageActionsPayloadTest {
     @Test
     public void TestGetReactions(){
         List<MessageActionsPayloadReaction> reactions = new ArrayList<MessageActionsPayloadReaction>();
-        MessageActionsPayload messageActionsPayload = new MessageActionsPayload(){
-            {
-                setReactions(reactions);
-            }
-        };
+        MessageActionsPayload messageActionsPayload = new MessageActionsPayload();
+        messageActionsPayload.setReactions(reactions);
         List<MessageActionsPayloadReaction> result = messageActionsPayload.getReactions();
 
         Assert.assertEquals(result, reactions);

--- a/samples/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/WelcomeUserBot.java
+++ b/samples/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/WelcomeUserBot.java
@@ -175,49 +175,45 @@ public class WelcomeUserBot extends ActivityHandler {
     }
 
     private CompletableFuture<ResourceResponse> sendIntroCard(TurnContext turnContext) {
-        HeroCard card = new HeroCard() {{
-            setTitle("Welcome to Bot Framework!");
-            setText(
-                "Welcome to Welcome Users bot sample! This Introduction card "
-                    + "is a great way to introduce your Bot to the user and suggest "
-                    + "some things to get them started. We use this opportunity to "
-                    + "recommend a few next steps for learning more creating and deploying bots."
-            );
-        }};
-
-        card.setImages(Collections.singletonList(new CardImage() {
-            {
-                setUrl("https://aka.ms/bf-welcome-card-image");
-            }
-        }));
-
-        card.setButtons(Arrays.asList(
-            new CardAction() {{
-                setType(ActionTypes.OPEN_URL);
-                setTitle("Get an overview");
-                setText("Get an overview");
-                setDisplayText("Get an overview");
-                setValue(
-                    "https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0"
-                );
-            }},
-            new CardAction() {{
-                setType(ActionTypes.OPEN_URL);
-                setTitle("Ask a question");
-                setText("Ask a question");
-                setDisplayText("Ask a question");
-                setValue("https://stackoverflow.com/questions/tagged/botframework");
-            }},
-            new CardAction() {{
-                setType(ActionTypes.OPEN_URL);
-                setTitle("Learn how to deploy");
-                setText("Learn how to deploy");
-                setDisplayText("Learn how to deploy");
-                setValue(
-                    "https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-deploy-azure?view=azure-bot-service-4.0"
-                );
-            }})
+        HeroCard card = new HeroCard();
+        card.setTitle("Welcome to Bot Framework!");
+        card.setText(
+            "Welcome to Welcome Users bot sample! This Introduction card "
+                + "is a great way to introduce your Bot to the user and suggest "
+                + "some things to get them started. We use this opportunity to "
+                + "recommend a few next steps for learning more creating and deploying bots."
         );
+
+        CardImage image = new CardImage();
+        image.setUrl("https://aka.ms/bf-welcome-card-image");
+
+        card.setImages(Collections.singletonList(image));
+
+        CardAction overviewAction = new CardAction();
+        overviewAction.setType(ActionTypes.OPEN_URL);
+        overviewAction.setTitle("Get an overview");
+        overviewAction.setText("Get an overview");
+        overviewAction.setDisplayText("Get an overview");
+        overviewAction.setValue(
+            "https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0"
+        );
+
+        CardAction questionAction = new CardAction();
+        questionAction.setType(ActionTypes.OPEN_URL);
+        questionAction.setTitle("Ask a question");
+        questionAction.setText("Ask a question");
+        questionAction.setDisplayText("Ask a question");
+        questionAction.setValue("https://stackoverflow.com/questions/tagged/botframework");
+
+        CardAction deployAction = new CardAction();
+        deployAction.setType(ActionTypes.OPEN_URL);
+        deployAction.setTitle("Learn how to deploy");
+        deployAction.setText("Learn how to deploy");
+        deployAction.setDisplayText("Learn how to deploy");
+        deployAction.setValue(
+            "https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-deploy-azure?view=azure-bot-service-4.0"
+        );
+        card.setButtons(Arrays.asList(overviewAction, questionAction, deployAction));
 
         Activity response = MessageFactory.attachment(card.toAttachment());
         return turnContext.sendActivity(response);

--- a/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/Cards.java
+++ b/samples/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/Cards.java
@@ -73,29 +73,24 @@ public class Cards {
     public static ReceiptCard getReceiptCard() {
         ReceiptCard receiptCard = new ReceiptCard();
         receiptCard.setTitle("John Doe");
-        receiptCard.setFacts(
-            new Fact("Order Number", "1234"), new Fact("Payment Method", "VISA 5555-****"));
-        receiptCard.setItems(
-            new ReceiptItem(){{
-                setTitle("Data Transfer");
-                setPrice("$ 38.45");
-                setQuantity("368");
-                setImage(new CardImage("https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png"));
-            }},
-            new ReceiptItem() {{
-                setTitle("App Service");
-                setPrice("$ 45.00");
-                setQuantity("720");
-                setImage(new CardImage("https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png"));
-            }}
-            );
+        ReceiptItem receiptDataTransfer = new ReceiptItem();
+        receiptDataTransfer.setTitle("Data Transfer");
+        receiptDataTransfer.setPrice("$ 38.45");
+        receiptDataTransfer.setQuantity("368");
+        receiptDataTransfer.setImage(new CardImage("https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png"));
+        ReceiptItem receiptAppService = new ReceiptItem();
+        receiptAppService.setTitle("App Service");
+        receiptAppService.setPrice("$ 45.00");
+        receiptAppService.setQuantity("720");
+        receiptAppService.setImage(new CardImage("https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png"));
+        receiptCard.setFacts(new Fact("Order Number", "1234"), new Fact("Payment Method", "VISA 5555-****"));
+        receiptCard.setItems(receiptDataTransfer, receiptAppService);
         receiptCard.setTax("$ 7.50");
         receiptCard.setTotal("$ 90.95");
-        receiptCard.setButtons(new CardAction(ActionTypes.OPEN_URL, "More information") {{
-                setImage(
-                    "https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png");
-                setValue("https://azure.microsoft.com/en-us/pricing/");
-        }});
+        CardAction cardAction = new CardAction(ActionTypes.OPEN_URL, "More information");
+        cardAction.setImage("https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png");
+        cardAction.setValue("https://azure.microsoft.com/en-us/pricing/");
+        receiptCard.setButtons(cardAction);
 
         return receiptCard;
     }

--- a/samples/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/bots/AdaptiveCardsBot.java
+++ b/samples/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/bots/AdaptiveCardsBot.java
@@ -83,10 +83,11 @@ public class AdaptiveCardsBot extends ActivityHandler {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            return new Attachment() {{
-                setContentType("application/vnd.microsoft.card.adaptive");
-                setContent(Serialization.jsonToTree(adaptiveCardJson));
-            }};
+            Attachment attachment = new Attachment();
+            attachment.setContentType("application/vnd.microsoft.card.adaptive");
+            attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
+
+            return attachment;
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/samples/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/SuggestedActionsBot.java
+++ b/samples/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/SuggestedActionsBot.java
@@ -94,35 +94,30 @@ public class SuggestedActionsBot extends ActivityHandler {
     private Activity createSuggestedActions() {
         Activity reply = MessageFactory.text("What is your favorite color?");
 
-        reply.setSuggestedActions(new SuggestedActions() {
-            {
-                setActions(Arrays.asList(new CardAction() {
-                    {
-                        setTitle("Red");
-                        setType(ActionTypes.IM_BACK);
-                        setValue("Red");
-                        setImage("https://via.placeholder.com/20/FF0000?text=R");
-                        setImageAltText("R");
-                    }
-                }, new CardAction() {
-                    {
-                        setTitle("Yellow");
-                        setType(ActionTypes.IM_BACK);
-                        setValue("Yellow");
-                        setImage("https://via.placeholder.com/20/FFFF00?text=Y");
-                        setImageAltText("Y");
-                    }
-                }, new CardAction() {
-                    {
-                        setTitle("Blue");
-                        setType(ActionTypes.IM_BACK);
-                        setValue("Blue");
-                        setImage("https://via.placeholder.com/20/0000FF?text=B");
-                        setImageAltText("B");
-                    }
-                }));
-            }
-        });
+        CardAction redAction = new CardAction();
+        redAction.setTitle("Red");
+        redAction.setType(ActionTypes.IM_BACK);
+        redAction.setValue("Red");
+        redAction.setImage("https://via.placeholder.com/20/FF0000?text=R");
+        redAction.setImageAltText("R");
+
+        CardAction yellowAction = new CardAction();
+        yellowAction.setTitle("Yellow");
+        yellowAction.setType(ActionTypes.IM_BACK);
+        yellowAction.setValue("Yellow");
+        yellowAction.setImage("https://via.placeholder.com/20/FFFF00?text=Y");
+        yellowAction.setImageAltText("Y");
+
+        CardAction blueAction = new CardAction();
+        blueAction.setTitle("Blue");
+        blueAction.setType(ActionTypes.IM_BACK);
+        blueAction.setValue("Blue");
+        blueAction.setImage("https://via.placeholder.com/20/0000FF?text=B");
+        blueAction.setImageAltText("B");
+
+        SuggestedActions actions = new SuggestedActions();
+        actions.setActions(Arrays.asList(redAction, yellowAction, blueAction));
+        reply.setSuggestedActions(actions);
 
         return reply;
     }

--- a/samples/11.qnamaker/src/main/java/com/microsoft/bot/sample/qnamaker/QnABot.java
+++ b/samples/11.qnamaker/src/main/java/com/microsoft/bot/sample/qnamaker/QnABot.java
@@ -22,19 +22,17 @@ public class QnABot extends ActivityHandler {
 
     @Override
     protected CompletableFuture<Void> onMessageActivity(TurnContext turnContext) {
-        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint() {{
-            setKnowledgeBaseId(configuration.getProperty("QnAKnowledgebaseId"));
-            setEndpointKey(configuration.getProperty("QnAEndpointKey"));
-            setHost(configuration.getProperty("QnAEndpointHostName"));
-        }};
+        QnAMakerEndpoint qnAMakerEndpoint = new QnAMakerEndpoint();
+        qnAMakerEndpoint.setKnowledgeBaseId(configuration.getProperty("QnAKnowledgebaseId"));
+        qnAMakerEndpoint.setEndpointKey(configuration.getProperty("QnAEndpointKey"));
+        qnAMakerEndpoint.setHost(configuration.getProperty("QnAEndpointHostName"));
 
         QnAMaker qnaMaker = new QnAMaker(qnAMakerEndpoint, null);
 
         LoggerFactory.getLogger(QnABot.class).info("Calling QnA Maker");
 
-        QnAMakerOptions options = new QnAMakerOptions() {{
-            setTop(1);
-        }};
+        QnAMakerOptions options = new QnAMakerOptions();
+        options.setTop(1);
 
         // The actual call to the QnA Maker service.
         return qnaMaker.getAnswers(turnContext, options)

--- a/samples/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DateResolverDialog.java
+++ b/samples/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DateResolverDialog.java
@@ -75,12 +75,10 @@ public class DateResolverDialog extends CancelAndHelpDialog {
             return stepContext.prompt("DateTimePrompt", promptOptions);
         }
 
-        DateTimeResolution dateTimeResolution = new DateTimeResolution() {{
-            setTimex(timex);
-        }};
-        List<DateTimeResolution> dateTimeResolutions = new ArrayList<DateTimeResolution>() {{
-            add(dateTimeResolution);
-        }};
+        DateTimeResolution dateTimeResolution = new DateTimeResolution();
+        dateTimeResolution.setTimex(timex);
+        List<DateTimeResolution> dateTimeResolutions = new ArrayList<DateTimeResolution>();
+        dateTimeResolutions.add(dateTimeResolution);
         return stepContext.next(dateTimeResolutions);
     }
 

--- a/samples/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
+++ b/samples/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
@@ -85,10 +85,10 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            return new Attachment() {{
-                setContentType("application/vnd.microsoft.card.adaptive");
-                setContent(Serialization.jsonToTree(adaptiveCardJson));
-            }};
+            Attachment attachment = new Attachment();
+            attachment.setContentType("application/vnd.microsoft.card.adaptive");
+            attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
+            return attachment;
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/samples/13.core-bot/src/main/java/com/microsoft/bot/sample/core/FlightBookingRecognizer.java
+++ b/samples/13.core-bot/src/main/java/com/microsoft/bot/sample/core/FlightBookingRecognizer.java
@@ -42,12 +42,8 @@ public class FlightBookingRecognizer implements Recognizer {
             // Set the recognizer options depending on which endpoint version you want to use.
             // More details can be found in
             // https://docs.microsoft.com/en-gb/azure/cognitive-services/luis/luis-migration-api-v3
-            LuisRecognizerOptionsV3 recognizerOptions = new LuisRecognizerOptionsV3(
-                luisApplication) {
-                {
-                    setIncludeInstanceData(true);
-                }
-            };
+            LuisRecognizerOptionsV3 recognizerOptions = new LuisRecognizerOptionsV3(luisApplication);
+            recognizerOptions.setIncludeInstanceData(true);
 
             this.recognizer = new LuisRecognizer(recognizerOptions);
         }

--- a/samples/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/AttachmentsBot.java
+++ b/samples/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/AttachmentsBot.java
@@ -76,18 +76,17 @@ public class AttachmentsBot extends ActivityHandler {
 
     private CompletableFuture<Void> displayOptions(TurnContext turnContext) {
         // Create a HeroCard with options for the user to interact with the bot.
-        HeroCard card = new HeroCard() {{
-            setText("You can upload an image or select one of the following choices");
+        HeroCard card = new HeroCard();
+        card.setText("You can upload an image or select one of the following choices");
 
-            // Note that some channels require different values to be used in order to get buttons to display text.
-            // In this code the emulator is accounted for with the 'title' parameter, but in other channels you may
-            // need to provide a value for other parameters like 'text' or 'displayText'.
-            setButtons(
-                new CardAction(ActionTypes.IM_BACK, "1. Inline Attachment", "1"),
-                new CardAction(ActionTypes.IM_BACK, "2. Internet Attachment", "2"),
-                new CardAction(ActionTypes.IM_BACK, "3. Uploaded Attachment", "3")
-            );
-        }};
+        // Note that some channels require different values to be used in order to get buttons to display text.
+        // In this code the emulator is accounted for with the 'title' parameter, but in other channels you may
+        // need to provide a value for other parameters like 'text' or 'displayText'.
+        card.setButtons(
+            new CardAction(ActionTypes.IM_BACK, "1. Inline Attachment", "1"),
+            new CardAction(ActionTypes.IM_BACK, "2. Internet Attachment", "2"),
+            new CardAction(ActionTypes.IM_BACK, "3. Uploaded Attachment", "3")
+        );
 
         Activity reply = MessageFactory.attachment(card.toAttachment());
         return turnContext.sendActivity(reply).thenApply(resourceResponse -> null);
@@ -200,11 +199,11 @@ public class AttachmentsBot extends ActivityHandler {
 
     // Creates an Attachment to be sent from the bot to the user from a HTTP URL.
     private CompletableFuture<Attachment> getInternetAttachment() {
-        return CompletableFuture.completedFuture(new Attachment() {{
-            setName("architecture-resize.png");
-            setContentType("image/png");
-            setContentUrl("https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png");
-        }});
+        Attachment attachment = new Attachment();
+        attachment.setName("architecture-resize.png");
+        attachment.setContentType("image/png");
+        attachment.setContentUrl("https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png");
+        return CompletableFuture.completedFuture(attachment);
     }
 
     private CompletableFuture<Attachment> getUploadedAttachment(TurnContext turnContext, String serviceUrl, String conversationId) {

--- a/samples/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
+++ b/samples/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
@@ -104,26 +104,19 @@ public class MultiLingualBot extends ActivityHandler {
             // than the default, then the translation middleware will pick it up from the user state and
             // translate messages both ways, i.e. user to bot and bot to user.
             Activity reply = MessageFactory.text("Choose your language:");
-            CardAction esAction = new CardAction() {
-                {
-                    setTitle("Español");
-                    setType(ActionTypes.POST_BACK);
-                    setValue(ENGLISH_SPANISH);
-                }
-            };
-            CardAction enAction = new CardAction() {
-                {
-                    setTitle("English");
-                    setType(ActionTypes.POST_BACK);
-                    setValue(ENGLISH_ENGLISH);
-                }
-            };
+            CardAction esAction = new CardAction();
+            esAction.setTitle("Español");
+            esAction.setType(ActionTypes.POST_BACK);
+            esAction.setValue(ENGLISH_SPANISH);
+
+            CardAction enAction = new CardAction();
+            enAction.setTitle("English");
+            enAction.setType(ActionTypes.POST_BACK);
+            enAction.setValue(ENGLISH_ENGLISH);
+
             List<CardAction> actions = new ArrayList<>(Arrays.asList(esAction, enAction));
-            SuggestedActions suggestedActions = new SuggestedActions() {
-                {
-                    setActions(actions);
-                }
-            };
+            SuggestedActions suggestedActions = new SuggestedActions();
+            suggestedActions.setActions(actions);
             reply.setSuggestedActions(suggestedActions);
             return turnContext.sendActivity(reply).thenApply(resourceResponse -> null);
         }
@@ -154,10 +147,10 @@ public class MultiLingualBot extends ActivityHandler {
         ) {
             String adaptiveCardJson = IOUtils.toString(input, StandardCharsets.UTF_8.toString());
 
-            return new Attachment() {{
-                setContentType("application/vnd.microsoft.card.adaptive");
-                setContent(Serialization.jsonToTree(adaptiveCardJson));
-            }};
+            Attachment attachment = new Attachment();
+            attachment.setContentType("application/vnd.microsoft.card.adaptive");
+            attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
+            return attachment;
         } catch (IOException e) {
             e.printStackTrace();
             return new Attachment();

--- a/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/TeamsMessagingExtensionsSearchBot.java
+++ b/samples/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/TeamsMessagingExtensionsSearchBot.java
@@ -48,37 +48,35 @@ public class TeamsMessagingExtensionsSearchBot extends TeamsActivityHandler {
                     ObjectNode data = Serialization.createObjectNode();
                     data.set("data", Serialization.objectToTree(item));
 
-                    ThumbnailCard previewCard = new ThumbnailCard() {{
-                        setTitle(item[0]);
-                        setTap(new CardAction() {{
-                            setType(ActionTypes.INVOKE);
-                            setValue(Serialization.toStringSilent(data));
-                        }});
-                    }};
+                    CardAction cardAction = new CardAction();
+                    cardAction.setType(ActionTypes.INVOKE);
+                    cardAction.setValue(Serialization.toStringSilent(data));
+                    ThumbnailCard previewCard = new ThumbnailCard();
+                    previewCard.setTitle(item[0]);
+                    previewCard.setTap(cardAction);
 
                     if (!StringUtils.isEmpty(item[4])) {
-                        previewCard.setImages(Collections.singletonList(new CardImage() {{
-                            setUrl(item[4]);
-                            setAlt("Icon");
-                        }}));
+                        CardImage cardImage = new CardImage();
+                        cardImage.setUrl(item[4]);
+                        cardImage.setAlt("Icon");
+                        previewCard.setImages(Collections.singletonList(cardImage));
                     }
 
-                    MessagingExtensionAttachment attachment = new MessagingExtensionAttachment() {{
-                        setContentType(HeroCard.CONTENTTYPE);
-                        setContent(new HeroCard() {{
-                            setTitle(item[0]);
-                        }});
-                        setPreview(previewCard.toAttachment());
-                    }};
+                    HeroCard heroCard = new HeroCard();
+                    heroCard.setTitle(item[0]);
+
+                    MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+                    attachment.setContentType(HeroCard.CONTENTTYPE);
+                    attachment.setContent(heroCard);
+                    attachment.setPreview(previewCard.toAttachment());
 
                     attachments.add(attachment);
                 }
 
-                MessagingExtensionResult composeExtension = new MessagingExtensionResult() {{
-                    setType("result");
-                    setAttachmentLayout("list");
-                    setAttachments(attachments);
-                }};
+                MessagingExtensionResult composeExtension = new MessagingExtensionResult();
+                composeExtension.setType("result");
+                composeExtension.setAttachmentLayout("list");
+                composeExtension.setAttachments(attachments);
 
                 return new MessagingExtensionResponse(composeExtension);
             });
@@ -92,33 +90,31 @@ public class TeamsMessagingExtensionsSearchBot extends TeamsActivityHandler {
 
         Map cardValue = (Map) query;
         List<String> data = (ArrayList) cardValue.get("data");
-        ThumbnailCard card = new ThumbnailCard() {{
-            setTitle(data.get(0));
-            setSubtitle(data.get(2));
-            setButtons(Arrays.asList(new CardAction() {{
-                setType(ActionTypes.OPEN_URL);
-                setTitle("Project");
-                setValue(data.get(3));
-            }}));
-        }};
+        CardAction cardAction = new CardAction();
+        cardAction.setType(ActionTypes.OPEN_URL);
+        cardAction.setTitle("Project");
+        cardAction.setValue(data.get(3));
+
+        ThumbnailCard card = new ThumbnailCard();
+        card.setTitle(data.get(0));
+        card.setSubtitle(data.get(2));
+        card.setButtons(Arrays.asList(cardAction));
 
         if (!StringUtils.isEmpty(data.get(4))) {
-            card.setImages(Collections.singletonList(new CardImage() {{
-                setUrl(data.get(4));
-                setAlt("Icon");
-            }}));
+            CardImage cardImage = new CardImage();
+            cardImage.setUrl(data.get(4));
+            cardImage.setAlt("Icon");
+            card.setImages(Collections.singletonList(cardImage));
         }
 
-        MessagingExtensionAttachment attachment = new MessagingExtensionAttachment() {{
-            setContentType(ThumbnailCard.CONTENTTYPE);
-            setContent(card);
-        }};
+        MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+        attachment.setContentType(ThumbnailCard.CONTENTTYPE);
+        attachment.setContent(card);
 
-        MessagingExtensionResult composeExtension = new MessagingExtensionResult() {{
-            setType("result");
-            setAttachmentLayout("list");
-            setAttachments(Collections.singletonList(attachment));
-        }};
+        MessagingExtensionResult composeExtension = new MessagingExtensionResult();
+        composeExtension.setType("result");
+        composeExtension.setAttachmentLayout("list");
+        composeExtension.setAttachments(Collections.singletonList(attachment));
         return CompletableFuture.completedFuture(new MessagingExtensionResponse(composeExtension));
     }
 

--- a/samples/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/TeamsMessagingExtensionsActionBot.java
+++ b/samples/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/TeamsMessagingExtensionsActionBot.java
@@ -44,26 +44,25 @@ public class TeamsMessagingExtensionsActionBot extends TeamsActivityHandler {
     ) {
         Map<String, String> actionData = (Map<String, String>) action.getData();
 
-        HeroCard card = new HeroCard() {{
-            setTitle(actionData.get("title"));
-            setSubtitle(actionData.get("subTitle"));
-            setText(actionData.get("text"));
-        }};
+        HeroCard card = new HeroCard();
+        card.setTitle(actionData.get("title"));
+        card.setSubtitle(actionData.get("subTitle"));
+        card.setText(actionData.get("text"));
 
-        List<MessagingExtensionAttachment> attachments = Arrays
-            .asList(new MessagingExtensionAttachment() {{
-                setContent(card);
-                setContentType(HeroCard.CONTENTTYPE);
-                setPreview(card.toAttachment());
-            }});
+        MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+        attachment.setContent(card);
+        attachment.setContentType(HeroCard.CONTENTTYPE);
+        attachment.setPreview(card.toAttachment());
+        List<MessagingExtensionAttachment> attachments = Arrays.asList(attachment);
 
-        return CompletableFuture.completedFuture(new MessagingExtensionActionResponse() {{
-            setComposeExtension(new MessagingExtensionResult() {{
-                setAttachments(attachments);
-                setAttachmentLayout("list");
-                setType("result");
-            }});
-        }});
+        MessagingExtensionResult result = new MessagingExtensionResult();
+        result.setAttachments(attachments);
+        result.setAttachmentLayout("list");
+        result.setType("result");
+        MessagingExtensionActionResponse response = new MessagingExtensionActionResponse();
+        response.setComposeExtension(result);
+
+        return CompletableFuture.completedFuture(response);
     }
 
     private CompletableFuture<MessagingExtensionActionResponse> shareMessageCommand(
@@ -72,12 +71,11 @@ public class TeamsMessagingExtensionsActionBot extends TeamsActivityHandler {
     ) {
         Map<String, String> actionData = (Map<String, String>) action.getData();
 
-        HeroCard card = new HeroCard() {{
-            setTitle(
-                action.getMessagePayload().getFrom().getUser() != null ? action.getMessagePayload()
-                    .getFrom().getUser().getDisplayName() : "");
-            setText(action.getMessagePayload().getBody().getContent());
-        }};
+        HeroCard card = new HeroCard();
+        card.setTitle(
+            action.getMessagePayload().getFrom().getUser() != null ? action.getMessagePayload()
+                .getFrom().getUser().getDisplayName() : "");
+        card.setText(action.getMessagePayload().getBody().getContent());
 
         if (action.getMessagePayload().getAttachments() != null && !action.getMessagePayload()
             .getAttachments().isEmpty()) {
@@ -88,22 +86,23 @@ public class TeamsMessagingExtensionsActionBot extends TeamsActivityHandler {
             Boolean.valueOf(actionData.get("includeImage"))
         ) : false;
         if (includeImage) {
-            card.setImages(Arrays.asList(new CardImage() {{
-                setUrl(
-                    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU");
-            }}));
+            CardImage cardImage = new CardImage();
+            cardImage.setUrl("https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU");
+            card.setImages(Arrays.asList(cardImage));
         }
 
-        return CompletableFuture.completedFuture(new MessagingExtensionActionResponse() {{
-            setComposeExtension(new MessagingExtensionResult() {{
-                setAttachmentLayout("list");
-                setType("result");
-                setAttachments(Arrays.asList(new MessagingExtensionAttachment() {{
-                    setContent(card);
-                    setContentType(HeroCard.CONTENTTYPE);
-                    setPreview(card.toAttachment());
-                }}));
-            }});
-        }});
+        MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+        attachment.setContent(card);
+        attachment.setContentType(HeroCard.CONTENTTYPE);
+        attachment.setPreview(card.toAttachment());
+
+        MessagingExtensionResult result = new MessagingExtensionResult();
+        result.setAttachmentLayout("list");
+        result.setType("result");
+        result.setAttachments(Arrays.asList(attachment));
+
+        MessagingExtensionActionResponse response = new MessagingExtensionActionResponse();
+        response.setComposeExtension(result);
+        return CompletableFuture.completedFuture(response);
     }
 }

--- a/samples/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
+++ b/samples/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
@@ -81,16 +81,17 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
                 }
             }
 
-            return new MessagingExtensionResponse(new MessagingExtensionResult() {{
-                setType("config");
-                setSuggestedActions(new MessagingExtensionSuggestedAction() {{
-                    setAction(new CardAction() {{
-                        setType(ActionTypes.OPEN_URL);
-                        setValue(String.format("%s/searchSettings.html?settings=%s",
-                            siteUrl, escapedSettings.get()));
-                    }});
-                }});
-            }});
+            CardAction cardAction = new CardAction();
+            cardAction.setType(ActionTypes.OPEN_URL);
+            cardAction.setValue(String.format("%s/searchSettings.html?settings=%s", siteUrl, escapedSettings.get()));
+
+            MessagingExtensionSuggestedAction suggestedAction = new MessagingExtensionSuggestedAction();
+            suggestedAction.setAction(cardAction);
+
+            MessagingExtensionResult result = new MessagingExtensionResult();
+            result.setType("config");
+            result.setSuggestedActions(suggestedAction);
+            return new MessagingExtensionResponse(result);
         });
     }
 
@@ -137,37 +138,35 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
                 ObjectNode data = Serialization.createObjectNode();
                 data.set("data", Serialization.objectToTree(item));
 
-                ThumbnailCard previewCard = new ThumbnailCard() {{
-                    setTitle(item[0]);
-                    setTap(new CardAction() {{
-                        setType(ActionTypes.INVOKE);
-                        setValue(data);
-                    }});
-                }};
+                CardAction cardAction = new CardAction();
+                cardAction.setType(ActionTypes.INVOKE);
+                cardAction.setValue(data);
+                ThumbnailCard previewCard = new ThumbnailCard();
+                previewCard.setTitle(item[0]);
+                previewCard.setTap(cardAction);
 
                 if (!StringUtils.isEmpty(item[4])) {
-                    previewCard.setImage(new CardImage() {{
-                        setUrl(item[4]);
-                        setAlt("Icon");
-                    }});
+                    CardImage cardImage = new CardImage();
+                    cardImage.setUrl(item[4]);
+                    cardImage.setAlt("Icon");
+                    previewCard.setImage(cardImage);
                 }
 
-                MessagingExtensionAttachment attachment = new MessagingExtensionAttachment() {{
-                    setContentType(HeroCard.CONTENTTYPE);
-                    setContent(new HeroCard() {{
-                        setTitle(item[0]);
-                    }});
-                    setPreview(previewCard.toAttachment());
-                }};
+                HeroCard heroCard = new HeroCard();
+                heroCard.setTitle(item[0]);
+                MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+                attachment.setContentType(HeroCard.CONTENTTYPE);
+                attachment.setContent(heroCard);
+                attachment.setPreview(previewCard.toAttachment());
 
                 attachments.add(attachment);
             }
 
-            return new MessagingExtensionResponse(new MessagingExtensionResult() {{
-                setType("result");
-                setAttachmentLayout("list");
-                setAttachments(attachments);
-            }});
+            MessagingExtensionResult result = new MessagingExtensionResult();
+            result.setType("result");
+            result.setAttachmentLayout("list");
+            result.setAttachments(attachments);
+            return new MessagingExtensionResponse(result);
         });
     }
 
@@ -188,23 +187,26 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
             .thenCompose(response -> {
                 if (response == null || StringUtils.isEmpty(response.getToken())) {
                     // There is no token, so the user has not signed in yet.
+
                     return tokenProvider.getOAuthSignInLink(turnContext, connectionName)
-                        .thenApply(link -> new MessagingExtensionResponse() {{
-                            setComposeExtension(new MessagingExtensionResult() {{
-                                setType("auth");
-                                setSuggestedActions(
-                                    new MessagingExtensionSuggestedAction() {{
-                                        setAction(
-                                            new CardAction() {{
-                                                setType(ActionTypes.OPEN_URL);
-                                                setValue(link);
-                                                setTitle("Bot Service OAuth");
-                                            }}
-                                        );
-                                    }}
-                                );
-                            }});
-                        }});
+                        .thenApply(link -> {
+                            MessagingExtensionResponse extensionResponse = new MessagingExtensionResponse();
+                            CardAction cardAction = new CardAction();
+                            cardAction.setType(ActionTypes.OPEN_URL);
+                            cardAction.setValue(extensionResponse);
+                            cardAction.setTitle("Bot Service OAuth");
+
+                            MessagingExtensionSuggestedAction suggestedAction = new MessagingExtensionSuggestedAction();
+                            suggestedAction.setAction(cardAction);
+
+                            MessagingExtensionResult result = new MessagingExtensionResult();
+                            result.setType("auth");
+                            result.setSuggestedActions(suggestedAction);
+
+                            extensionResponse.setComposeExtension(result);
+
+                            return extensionResponse;
+                        });
                 }
 
                 String search = "";
@@ -223,33 +225,30 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
     ) {
         Map cardValue = (Map) query;
         List<String> data = (ArrayList) cardValue.get("data");
-        ThumbnailCard card = new ThumbnailCard() {{
-            setTitle(data.get(0));
-            setSubtitle(data.get(2));
-            setButtons(Arrays.asList(new CardAction() {{
-                setType(ActionTypes.OPEN_URL);
-                setTitle("Project");
-                setValue(data.get(3));
-            }}));
-        }};
-
+        CardAction cardAction = new CardAction();
+        cardAction.setType(ActionTypes.OPEN_URL);
+        cardAction.setTitle("Project");
+        cardAction.setValue(data.get(3));
+        ThumbnailCard card = new ThumbnailCard();
+        card.setTitle(data.get(0));
+        card.setSubtitle(data.get(2));
+        card.setButtons(Arrays.asList(cardAction));
+        
         if (!StringUtils.isEmpty(data.get(4))) {
-            card.setImage(new CardImage() {{
-                setUrl(data.get(4));
-                setAlt("Icon");
-            }});
+            CardImage cardImage = new CardImage();
+            cardImage.setUrl(data.get(4));
+            cardImage.setAlt("Icon");
+            card.setImage(cardImage);
         }
 
-        MessagingExtensionAttachment attachment = new MessagingExtensionAttachment() {{
-            setContentType(ThumbnailCard.CONTENTTYPE);
-            setContent(card);
-        }};
+        MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+        attachment.setContentType(ThumbnailCard.CONTENTTYPE);
+        attachment.setContent(card);
 
-        MessagingExtensionResult composeExtension = new MessagingExtensionResult() {{
-            setType("result");
-            setAttachmentLayout("list");
-            setAttachments(Collections.singletonList(attachment));
-        }};
+        MessagingExtensionResult composeExtension = new MessagingExtensionResult();
+        composeExtension.setType("result");
+        composeExtension.setAttachmentLayout("list");
+        composeExtension.setAttachments(Collections.singletonList(attachment));
 
         return CompletableFuture.completedFuture(new MessagingExtensionResponse(composeExtension));
     }
@@ -269,20 +268,25 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
     ) {
         if (action.getCommandId().toUpperCase().equals("SIGNOUTCOMMAND")) {
             UserTokenProvider tokenProvider = (UserTokenProvider) turnContext.getAdapter();
+
             return tokenProvider.signOutUser(
                 turnContext,
                 connectionName,
                 turnContext.getActivity().getFrom().getId()
-            ).thenApply(response -> new MessagingExtensionActionResponse() {{
-                setTask(new TaskModuleContinueResponse() {{
-                    setValue(new TaskModuleTaskInfo() {{
-                        setCard(createAdaptiveCardAttachment());
-                        setHeight(200);
-                        setWidth(400);
-                        setTitle("Adaptive Card: Inputs");
-                    }});
-                }});
-            }});
+            ).thenApply(response -> {
+                TaskModuleTaskInfo taskInfo = new TaskModuleTaskInfo();
+                taskInfo.setCard(createAdaptiveCardAttachment());
+                taskInfo.setHeight(200);
+                taskInfo.setWidth(400);
+                taskInfo.setTitle("Adaptive Card: Inputs");
+
+                TaskModuleContinueResponse continueResponse = new TaskModuleContinueResponse();
+                continueResponse.setValue(taskInfo);
+
+                MessagingExtensionActionResponse actionResponse = new MessagingExtensionActionResponse();
+                actionResponse.setTask(continueResponse);
+                return actionResponse;
+            });
         }
 
         return notImplemented();
@@ -295,10 +299,10 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
         ) {
             String adaptiveCardJson = IOUtils.toString(input, StandardCharsets.UTF_8.toString());
 
-            return new Attachment() {{
-                setContentType("application/vnd.microsoft.card.adaptive");
-                setContent(Serialization.jsonToTree(adaptiveCardJson));
-            }};
+            Attachment attachment = new Attachment();
+            attachment.setContentType("application/vnd.microsoft.card.adaptive");
+            attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
+            return attachment;
         } catch (IOException e) {
             (LoggerFactory.getLogger(TeamsMessagingExtensionsSearchAuthConfigBot.class))
                 .error("Unable to createAdaptiveCardAttachment", e);
@@ -312,31 +316,35 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
 
         List<MessagingExtensionAttachment> attachments = new ArrayList<>();
         for (Message msg : messages) {
-            attachments.add(new MessagingExtensionAttachment() {{
-                setContentType(HeroCard.CONTENTTYPE);
-                setContent(new HeroCard() {{
-                    setTitle(msg.from.emailAddress.address);
-                    setSubtitle(msg.subject);
-                    setText(msg.body.content);
-                }});
-                setPreview(new ThumbnailCard() {{
-                    setTitle(msg.from.emailAddress.address);
-                    setText(String.format("%s<br />%s", msg.subject, msg.bodyPreview));
-                    setImage(new CardImage() {{
-                        setUrl(
-                            "https://raw.githubusercontent.com/microsoft/botbuilder-samples/master/docs/media/OutlookLogo.jpg"
-                        );
-                        setAlt("Outlook logo");
-                    }});
-                }}.toAttachment());
-            }});
+
+            CardImage cardImage = new CardImage();
+            cardImage.setUrl("https://raw.githubusercontent.com/microsoft/botbuilder-samples/master/docs/media/OutlookLogo.jpg");
+            cardImage.setAlt("Outlook logo");
+
+            HeroCard heroCard = new HeroCard();
+            heroCard.setTitle(msg.from.emailAddress.address);
+            heroCard.setSubtitle(msg.subject);
+            heroCard.setText(msg.body.content);
+
+            ThumbnailCard thumbnailCard = new ThumbnailCard();
+            thumbnailCard.setTitle(msg.from.emailAddress.address);
+            thumbnailCard.setText(String.format("%s<br />%s", msg.subject, msg.bodyPreview));
+            thumbnailCard.setImage(cardImage);
+
+            MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+            attachment.setContentType(HeroCard.CONTENTTYPE);
+            attachment.setContent(heroCard);
+            attachment.setPreview(thumbnailCard.toAttachment());
+
+            attachments.add(attachment);
         }
 
-        return new MessagingExtensionResult() {{
-            setType("result");
-            setAttachmentLayout("list");
-            setAttachments(attachments);
-        }};
+        MessagingExtensionResult result = new MessagingExtensionResult();
+        result.setType("result");
+        result.setAttachmentLayout("list");
+        result.setAttachments(attachments);
+
+        return result;
     }
 
     private CompletableFuture<List<String[]>> findPackages(String text) {

--- a/samples/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/TeamsMessagingExtensionsActionPreviewBot.java
+++ b/samples/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/TeamsMessagingExtensionsActionPreviewBot.java
@@ -64,18 +64,20 @@ public class TeamsMessagingExtensionsActionPreviewBot extends TeamsActivityHandl
 
         Attachment adaptiveCardEditor = getAdaptiveCardAttachment("adaptiveCardEditor.json");
 
-        return CompletableFuture.completedFuture(
-            new MessagingExtensionActionResponse(){{
-                setTask(new TaskModuleContinueResponse(){{
-                    setValue(new TaskModuleTaskInfo(){{
-                        setCard(adaptiveCardEditor);
-                        setWidth(500);
-                        setHeight(450);
-                        setTitle("Task Module Fetch Example");
-                    }});
-                    setType("continue");
-                }});
-            }});
+        TaskModuleTaskInfo taskInfo = new TaskModuleTaskInfo();
+        taskInfo.setCard(adaptiveCardEditor);
+        taskInfo.setWidth(500);
+        taskInfo.setHeight(450);
+        taskInfo.setTitle("Task Module Fetch Example");
+
+        TaskModuleContinueResponse continueResponse = new TaskModuleContinueResponse();
+        continueResponse.setValue(taskInfo);
+        continueResponse.setType("continue");
+
+        MessagingExtensionActionResponse actionResponse = new MessagingExtensionActionResponse();
+        actionResponse.setTask(continueResponse);
+
+        return CompletableFuture.completedFuture(actionResponse);
     }
 
     @Override
@@ -87,12 +89,14 @@ public class TeamsMessagingExtensionsActionPreviewBot extends TeamsActivityHandl
 
         updateAttachmentAdaptiveCard(adaptiveCard, action);
 
-        return CompletableFuture.completedFuture(new MessagingExtensionActionResponse(){{
-            setComposeExtension(new MessagingExtensionResult(){{
-                setType("botMessagePreview");
-                setActivityPreview(MessageFactory.attachment(adaptiveCard));
-            }});
-        }});
+        MessagingExtensionResult result = new MessagingExtensionResult();
+        result.setType("botMessagePreview");
+        result.setActivityPreview(MessageFactory.attachment(adaptiveCard));
+
+        MessagingExtensionActionResponse response = new MessagingExtensionActionResponse();
+        response.setComposeExtension(result);
+
+        return CompletableFuture.completedFuture(response);
     }
 
     @Override
@@ -107,17 +111,20 @@ public class TeamsMessagingExtensionsActionPreviewBot extends TeamsActivityHandl
         Attachment previewCard = preview.getAttachments().get(0);
         updateAttachmentAdaptiveCardEdit(adaptiveCard, previewCard);
 
-        return CompletableFuture.completedFuture(new MessagingExtensionActionResponse(){{
-            setTask(new TaskModuleContinueResponse(){{
-                setValue(new TaskModuleTaskInfo(){{
-                    setCard(adaptiveCard);
-                    setHeight(450);
-                    setWidth(500);
-                    setTitle("Task Module Fetch Example");
-                }});
-                setType("continue");
-            }});
-        }});
+        TaskModuleTaskInfo taskInfo = new TaskModuleTaskInfo();
+        taskInfo.setCard(adaptiveCard);
+        taskInfo.setHeight(450);
+        taskInfo.setWidth(500);
+        taskInfo.setTitle("Task Module Fetch Example");
+
+        TaskModuleContinueResponse continueResponse = new TaskModuleContinueResponse();
+        continueResponse.setValue(taskInfo);
+        continueResponse.setType("continue");
+
+        MessagingExtensionActionResponse actionResponse = new MessagingExtensionActionResponse();
+        actionResponse.setTask(continueResponse);
+
+        return CompletableFuture.completedFuture(actionResponse);
     }
 
     @Override
@@ -153,10 +160,11 @@ public class TeamsMessagingExtensionsActionPreviewBot extends TeamsActivityHandl
                 .getResourceAsStream(fileName);
             String content = IOUtils.toString(input, StandardCharsets.UTF_8);
 
-            return new Attachment(){{
-                setContentType("application/vnd.microsoft.card.adaptive");
-                setContent(new ObjectMapper().readValue(content, AdaptiveCard.class));
-            }};
+            Attachment attachment = new Attachment();
+            attachment.setContentType("application/vnd.microsoft.card.adaptive");
+            attachment.setContent(new ObjectMapper().readValue(content, AdaptiveCard.class));
+
+            return attachment;
         } catch (IOException e) {
             LoggerFactory.getLogger(TeamsMessagingExtensionsActionPreviewBot.class)
                 .error("getAdaptiveCardAttachment", e);

--- a/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/TeamsTaskModuleBot.java
+++ b/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/TeamsTaskModuleBot.java
@@ -143,17 +143,16 @@ public class TeamsTaskModuleBot extends TeamsActivityHandler {
     }
 
     private Attachment getTaskModuleHeroCardOptions() {
-        List<CardAction> buttons = actions.stream().map(cardType ->
-            new TaskModuleAction(cardType.getButtonTitle(),
-                new CardTaskFetchValue<String>() {{
-                    setData(cardType.getId());
-                }})
-        ).collect(Collectors.toCollection(ArrayList::new));
+        List<CardAction> buttons = actions.stream().map(cardType -> {
+            CardTaskFetchValue fetchValue = new CardTaskFetchValue<String>();
+            fetchValue.setData(cardType.getId());
+            TaskModuleAction moduleAction = new TaskModuleAction(cardType.getButtonTitle(), fetchValue);
+            return moduleAction;
+            }).collect(Collectors.toCollection(ArrayList::new));
 
-        HeroCard card = new HeroCard() {{
-            setTitle("Task Module Invocation from Hero Card");
-            setButtons(buttons);
-        }};
+        HeroCard card = new HeroCard();
+        card.setTitle("Task Module Invocation from Hero Card");
+        card.setButtons(buttons);
         return card.toAttachment();
     }
 
@@ -164,12 +163,12 @@ public class TeamsTaskModuleBot extends TeamsActivityHandler {
             String cardTemplate = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
 
             List<Map<String,Object>> cardActions = actions.stream().map(cardType -> {
+                AdaptiveCardTaskFetchValue fetchValue = new AdaptiveCardTaskFetchValue<String>();
+                fetchValue.setData(cardType.getId());
                 Map<String, Object> a = new HashMap<>();
                 a.put("type", "Action.Submit");
                 a.put("title", cardType.getButtonTitle());
-                a.put("data", new AdaptiveCardTaskFetchValue<String>() {{
-                    setData(cardType.getId());
-                }});
+                a.put("data", fetchValue);
                 return a;
             }).collect(Collectors.toCollection(ArrayList::new));
 
@@ -193,9 +192,9 @@ public class TeamsTaskModuleBot extends TeamsActivityHandler {
     }
 
     private Attachment adaptiveCardAttachmentFromJson(String json) throws IOException {
-        return new Attachment() {{
-            setContentType("application/vnd.microsoft.card.adaptive");
-            setContent(new ObjectMapper().readValue(json, ObjectNode.class));
-        }};
+        Attachment attachment = new Attachment();
+        attachment.setContentType("application/vnd.microsoft.card.adaptive");
+        attachment.setContent(new ObjectMapper().readValue(json, ObjectNode.class));
+        return attachment;
     }
 }

--- a/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/models/TaskModuleResponseFactory.java
+++ b/samples/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/models/TaskModuleResponseFactory.java
@@ -10,19 +10,19 @@ import com.microsoft.bot.schema.teams.TaskModuleTaskInfo;
 
 public final class TaskModuleResponseFactory {
     public static TaskModuleResponse createResponse(String message) {
-        return new TaskModuleResponse() {{
-            setTask(new TaskModuleMessageResponse() {{
-                setValue(message);
-            }});
-        }};
+        TaskModuleMessageResponse taskModuleMessageResponse = new TaskModuleMessageResponse();
+        taskModuleMessageResponse.setValue(message);
+        TaskModuleResponse taskModuleResponse = new TaskModuleResponse();
+        taskModuleResponse.setTask(taskModuleMessageResponse);
+        return taskModuleResponse;
     }
 
     public static TaskModuleResponse createResponse(TaskModuleTaskInfo taskInfo) {
-        return new TaskModuleResponse() {{
-            setTask(new TaskModuleContinueResponse() {{
-                setValue(taskInfo);
-            }});
-        }};
+        TaskModuleContinueResponse taskModuleContinueResponse = new TaskModuleContinueResponse();
+        taskModuleContinueResponse.setValue(taskInfo);
+        TaskModuleResponse taskModuleResponse = new TaskModuleResponse();
+        taskModuleResponse.setTask(taskModuleContinueResponse);
+        return taskModuleResponse;
     }
 
     public static TaskModuleResponse toTaskModuleResponse(TaskModuleTaskInfo taskInfo) {

--- a/samples/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/LinkUnfurlingBot.java
+++ b/samples/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/LinkUnfurlingBot.java
@@ -31,25 +31,22 @@ public class LinkUnfurlingBot extends TeamsActivityHandler {
         TurnContext turnContext,
         AppBasedLinkQuery query
     ) {
-        ThumbnailCard card = new ThumbnailCard() {{
-            setTitle("Thumbnail Card");
-            setText(query.getUrl());
-            setImages(Collections.singletonList(
-                new CardImage(
-                    "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png")
-            ));
-        }};
+        ThumbnailCard card = new ThumbnailCard();
+        card.setTitle("Thumbnail Card");
+        card.setText(query.getUrl());
+        card.setImages(Collections.singletonList(
+            new CardImage("https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png")
+        ));
 
-        MessagingExtensionAttachment attachments = new MessagingExtensionAttachment() {{
-            setContentType(HeroCard.CONTENTTYPE);
-            setContent(card);
-        }};
 
-        MessagingExtensionResult result = new MessagingExtensionResult() {{
-            setAttachmentLayout("list");
-            setType("result");
-            setAttachments(Collections.singletonList(attachments));
-        }};
+        MessagingExtensionAttachment attachments = new MessagingExtensionAttachment();
+        attachments.setContentType(HeroCard.CONTENTTYPE);
+        attachments.setContent(card);
+
+        MessagingExtensionResult result = new MessagingExtensionResult();
+        result.setAttachmentLayout("list");
+        result.setType("result");
+        result.setAttachments(Collections.singletonList(attachments));
 
         return CompletableFuture.completedFuture(new MessagingExtensionResponse(result));
     }
@@ -63,26 +60,23 @@ public class LinkUnfurlingBot extends TeamsActivityHandler {
 
         // These commandIds are defined in the Teams App Manifest.
         if (StringUtils.equalsIgnoreCase("searchQuery", query.getCommandId())) {
-            HeroCard card = new HeroCard() {{
-                setTitle("This is a Link Unfurling Sample");
-                setSubtitle("It will unfurl links from *.BotFramework.com");
-                setText("This sample demonstrates how to handle link unfurling in Teams.  "
-                    + "Please review the readme for more information.");
-            }};
+            HeroCard card = new HeroCard();
+            card.setTitle("This is a Link Unfurling Sample");
+            card.setSubtitle("It will unfurl links from *.BotFramework.com");
+            card.setText("This sample demonstrates how to handle link unfurling in Teams.  "
+                + "Please review the readme for more information.");
 
-            return CompletableFuture.completedFuture(new MessagingExtensionResponse(
-                new MessagingExtensionResult() {{
-                    setAttachmentLayout("list");
-                    setType("result");
-                    setAttachment(
-                        new MessagingExtensionAttachment() {{
-                            setContent(card);
-                            setContentType(HeroCard.CONTENTTYPE);
-                            setPreview(card.toAttachment());
-                        }}
-                    );
-                }}
-            ));
+            MessagingExtensionAttachment attachment = new MessagingExtensionAttachment();
+            attachment.setContent(card);
+            attachment.setContentType(HeroCard.CONTENTTYPE);
+            attachment.setPreview(card.toAttachment());
+
+            MessagingExtensionResult result = new MessagingExtensionResult();
+            result.setAttachmentLayout("list");
+            result.setType("result");
+            result.setAttachment(attachment);
+
+            return CompletableFuture.completedFuture(new MessagingExtensionResponse(result));
         }
 
         return notImplemented(String.format("Invalid CommandId: %s", query.getCommandId()));

--- a/samples/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/TeamsFileUploadBot.java
+++ b/samples/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/TeamsFileUploadBot.java
@@ -89,18 +89,16 @@ public class TeamsFileUploadBot extends TeamsActivityHandler {
         Map<String, String> consentContext = new HashMap<>();
         consentContext.put("filename", filename);
 
-        FileConsentCard fileCard = new FileConsentCard() {{
-            setDescription("This is the file I want to send you");
-            setSizeInBytes(filesize);
-            setAcceptContext(consentContext);
-            setDeclineContext(consentContext);
-        }};
+        FileConsentCard fileCard = new FileConsentCard();
+        fileCard.setDescription("This is the file I want to send you");
+        fileCard.setSizeInBytes(filesize);
+        fileCard.setAcceptContext(consentContext);
+        fileCard.setDeclineContext(consentContext);
 
-        Attachment asAttachment = new Attachment() {{
-            setContent(fileCard);
-            setContentType(FileConsentCard.CONTENT_TYPE);
-            setName(filename);
-        }};
+        Attachment asAttachment = new Attachment();
+        asAttachment.setContent(fileCard);
+        asAttachment.setContentType(FileConsentCard.CONTENT_TYPE);
+        asAttachment.setName(filename);
 
         Activity reply = turnContext.getActivity().createReply();
         reply.setAttachments(Collections.singletonList(asAttachment));
@@ -111,17 +109,15 @@ public class TeamsFileUploadBot extends TeamsActivityHandler {
     private CompletableFuture<Void> fileUploadCompleted(
         TurnContext turnContext, FileConsentCardResponse fileConsentCardResponse
     ) {
-        FileInfoCard downloadCard = new FileInfoCard() {{
-            setUniqueId(fileConsentCardResponse.getUploadInfo().getUniqueId());
-            setFileType(fileConsentCardResponse.getUploadInfo().getFileType());
-        }};
+        FileInfoCard downloadCard = new FileInfoCard();
+        downloadCard.setUniqueId(fileConsentCardResponse.getUploadInfo().getUniqueId());
+        downloadCard.setFileType(fileConsentCardResponse.getUploadInfo().getFileType());
 
-        Attachment asAttachment = new Attachment() {{
-            setContent(downloadCard);
-            setContentType(FileInfoCard.CONTENT_TYPE);
-            setName(fileConsentCardResponse.getUploadInfo().getName());
-            setContentUrl(fileConsentCardResponse.getUploadInfo().getContentUrl());
-        }};
+        Attachment asAttachment = new Attachment();
+        asAttachment.setContent(downloadCard);
+        asAttachment.setContentType(FileInfoCard.CONTENT_TYPE);
+        asAttachment.setName(fileConsentCardResponse.getUploadInfo().getName());
+        asAttachment.setContentUrl(fileConsentCardResponse.getUploadInfo().getContentUrl());
 
         Activity reply = MessageFactory.text(
             String.format(

--- a/samples/57.teams-conversation-bot/src/main/java/com/microsoft/bot/sample/teamsconversation/TeamsConversationBot.java
+++ b/samples/57.teams-conversation-bot/src/main/java/com/microsoft/bot/sample/teamsconversation/TeamsConversationBot.java
@@ -72,13 +72,10 @@ public class TeamsConversationBot extends TeamsActivityHandler {
                     int count = 0;
                 };
 
-                HeroCard card = new HeroCard() {
-                    {
-                        setTitle("Welcome Card");
-                        setText("Click the buttons below to update this card");
-                        setButtons(getHeroCardButtons(value));
-                    }
-                };
+                HeroCard card = new HeroCard();
+                card.setTitle("Welcome Card");
+                card.setText("Click the buttons below to update this card");
+                card.setButtons(getHeroCardButtons(value));
 
                 return turnContext.sendActivity(MessageFactory.attachment(card.toAttachment()))
                     .thenApply(resourceResponse -> null);
@@ -130,14 +127,11 @@ public class TeamsConversationBot extends TeamsActivityHandler {
                         + ". I'm a Teams conversation bot."
                 );
 
-                ConversationParameters conversationParameters = new ConversationParameters() {
-                    {
-                        setIsGroup(false);
-                        setBot(turnContext.getActivity().getRecipient());
-                        setMembers(Collections.singletonList(member));
-                        setTenantId(turnContext.getActivity().getConversation().getTenantId());
-                    }
-                };
+                ConversationParameters conversationParameters = new ConversationParameters();
+                conversationParameters.setIsGroup(false);
+                conversationParameters.setBot(turnContext.getActivity().getRecipient());
+                conversationParameters.setMembers(Collections.singletonList(member));
+                conversationParameters.setTenantId(turnContext.getActivity().getConversation().getTenantId());
 
                 conversations.add(
                     ((BotFrameworkAdapter) turnContext.getAdapter()).createConversation(
@@ -170,13 +164,10 @@ public class TeamsConversationBot extends TeamsActivityHandler {
         Map data = (Map) turnContext.getActivity().getValue();
         data.put("count", (int) data.get("count") + 1);
 
-        HeroCard card = new HeroCard() {
-            {
-                setTitle("Welcome Card");
-                setText("Update count - " + data.get("count"));
-                setButtons(getHeroCardButtons(data));
-            }
-        };
+        HeroCard card = new HeroCard();
+        card.setTitle("Welcome Card");
+        card.setText("Update count - " + data.get("count"));
+        card.setButtons(getHeroCardButtons(data));
 
         Activity updatedActivity = MessageFactory.attachment(card.toAttachment());
         updatedActivity.setId(turnContext.getActivity().getReplyToId());
@@ -185,32 +176,28 @@ public class TeamsConversationBot extends TeamsActivityHandler {
     }
 
     private List<CardAction> getHeroCardButtons(Object value) {
-        return Arrays.asList(new CardAction() {
-            {
-                setType(ActionTypes.MESSAGE_BACK);
-                setTitle("Update Card");
-                setText("UpdateCardAction");
-                setValue(value);
-            }
-        }, new CardAction() {
-            {
-                setType(ActionTypes.MESSAGE_BACK);
-                setTitle("Message All Members");
-                setText("MessageAllMembers");
-            }
-        }, new CardAction() {
-            {
-                setType(ActionTypes.MESSAGE_BACK);
-                setTitle("Delete card");
-                setText("Delete");
-            }
-        }, new CardAction() {
-            {
-                setType(ActionTypes.MESSAGE_BACK);
-                setTitle("Who am I?");
-                setText("MentionMe");
-            }
-        });
+        CardAction updateAction = new CardAction();
+        updateAction.setType(ActionTypes.MESSAGE_BACK);
+        updateAction.setTitle("Update Card");
+        updateAction.setText("UpdateCardAction");
+        updateAction.setValue(value);
+
+        CardAction allMembersAction = new CardAction();
+        allMembersAction.setType(ActionTypes.MESSAGE_BACK);
+        allMembersAction.setTitle("Message All Members");
+        allMembersAction.setText("MessageAllMembers");
+
+        CardAction deleteAction = new CardAction();
+        deleteAction.setType(ActionTypes.MESSAGE_BACK);
+        deleteAction.setTitle("Delete card");
+        deleteAction.setText("Delete");
+
+        CardAction mentionAction = new CardAction();
+        mentionAction.setType(ActionTypes.MESSAGE_BACK);
+        mentionAction.setTitle("Who am I?");
+        mentionAction.setText("MentionMe");
+
+        return Arrays.asList(updateAction, allMembersAction, deleteAction, mentionAction);
     }
 
     private CompletableFuture<Void> mentionActivity(TurnContext turnContext) {

--- a/samples/58.teams-start-new-thread-in-channel/src/main/java/com/microsoft/bot/sample/teamsstartnewthread/TeamsStartNewThreadBot.java
+++ b/samples/58.teams-start-new-thread-in-channel/src/main/java/com/microsoft/bot/sample/teamsstartnewthread/TeamsStartNewThreadBot.java
@@ -51,11 +51,10 @@ public class TeamsStartNewThreadBot extends TeamsActivityHandler {
                 .set("id", JsonNodeFactory.instance.textNode(teamsChannelId))
         );
 
-        ConversationParameters conversationParameters = new ConversationParameters(){{
-            setIsGroup(true);
-            setActivity(message);
-            setChannelData(channelData);
-        }};
+        ConversationParameters conversationParameters = new ConversationParameters();
+        conversationParameters.setIsGroup(true);
+        conversationParameters.setActivity(message);
+        conversationParameters.setChannelData(channelData);
 
         BotFrameworkAdapter adapter = (BotFrameworkAdapter)turnContext.getAdapter();
 

--- a/samples/81.skills-skilldialog/dialog-root-bot/src/main/java/com/microsoft/bot/sample/dialogrootbot/Bots/RootBot.java
+++ b/samples/81.skills-skilldialog/dialog-root-bot/src/main/java/com/microsoft/bot/sample/dialogrootbot/Bots/RootBot.java
@@ -82,12 +82,11 @@ public class RootBot<T extends Dialog> extends ActivityHandler {
             IOUtils.copy(bomIn, writer, StandardCharsets.UTF_8);
             content = writer.toString();
             bomIn.close();
-            return new Attachment() {
-                {
-                    setContentType("application/vnd.microsoft.card.adaptive");
-                    setContent(new JacksonAdapter().serializer().readValue(content, AdaptiveCard.class));
-                }
-            };
+            Attachment attachment = new Attachment();
+            attachment.setContentType("application/vnd.microsoft.card.adaptive");
+            attachment.setContent(new JacksonAdapter().serializer().readValue(content, AdaptiveCard.class));
+
+            return attachment;
         } catch (IOException e) {
             LoggerFactory.getLogger(RootBot.class).error("createAdaptiveCardAttachment", e);
         }


### PR DESCRIPTION
Fixes #1067

## Description
We replaced all the double brace initialization from [samples](https://github.com/microsoft/botbuilder-java/tree/main/samples) and [libraries](https://github.com/microsoft/botbuilder-java/tree/main/libraries) (code + unit tests) to avoid serialization issues.

## Specific Changes
- Replace double brace initialization to standard initialization in libraries
- Replace double brace initialization to standard initialization in samples

## Testing
We double checked the behavior of all the samples and the execution of the unit tests of each library.

_Successful mvn clean install execution after changes_
![image](https://user-images.githubusercontent.com/11904023/112684657-16728b00-8e52-11eb-8746-dd9441ca8c91.png)

_Successful communication of the 17.multilingual-bot sample after changes_
![image](https://user-images.githubusercontent.com/11904023/112684812-59ccf980-8e52-11eb-87da-d314630e4864.png)

_Successful communication of the 49.qnamaker-all-features sample after changes_
![image](https://user-images.githubusercontent.com/11904023/112685032-ba5c3680-8e52-11eb-85ca-823f2b31d9c4.png)