### PR TITLE
Update telemetry to log attachments

### DIFF
--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TelemetryConstants.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TelemetryConstants.java
@@ -11,6 +11,7 @@ public final class TelemetryConstants {
 
     }
 
+    public static final String ATTACHMENTSPROPERTY = "attachments";
     public static final String CHANNELIDPROPERTY = "channelId";
     public static final String CONVERSATIONIDPROPERTY = "conversationId";
     public static final String CONVERSATIONNAMEPROPERTY = "conversationName";

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TelemetryLoggerMiddleware.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/TelemetryLoggerMiddleware.java
@@ -188,6 +188,7 @@ public class TelemetryLoggerMiddleware implements Middleware {
      *         {@link BotTelemetryClient#trackEvent} method for the
      *         BotMessageReceived event.
      */
+    @SuppressWarnings("PMD.EmptyCatchBlock")
     protected CompletableFuture<Map<String, String>> fillReceiveEventProperties(
         Activity activity,
         Map<String, String> additionalProperties
@@ -216,6 +217,14 @@ public class TelemetryLoggerMiddleware implements Middleware {
 
             if (!StringUtils.isEmpty(activity.getSpeak())) {
                 properties.put(TelemetryConstants.SPEAKPROPERTY, activity.getSpeak());
+            }
+
+            if (activity.getAttachments() != null && activity.getAttachments().size() > 0) {
+                try {
+                    properties.put(TelemetryConstants.ATTACHMENTSPROPERTY,
+                                   Serialization.toString(activity.getAttachments()));
+                } catch (JsonProcessingException e) {
+                }
             }
         }
 

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TelemetryMiddlewareTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TelemetryMiddlewareTests.java
@@ -9,6 +9,7 @@ import com.microsoft.bot.builder.adapters.TestFlow;
 import com.microsoft.bot.connector.Channels;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ActivityTypes;
+import com.microsoft.bot.schema.Attachment;
 import com.microsoft.bot.schema.ChannelAccount;
 import com.microsoft.bot.schema.ResourceResponse;
 import com.microsoft.bot.schema.Serialization;
@@ -527,6 +528,45 @@ public class TelemetryMiddlewareTests {
             StringUtils.equals(properties.get(4).get("ImportantProperty"), "ImportantValue")
         );
     }
+
+    @Test
+    public void Telemetry_LogAttachments() throws JsonProcessingException {
+        BotTelemetryClient mockTelemetryClient = mock(BotTelemetryClient.class);
+        TestAdapter adapter = new TestAdapter(Channels.MSTEAMS).use(
+            new TelemetryLoggerMiddleware(mockTelemetryClient, true)
+        );
+
+        TeamInfo teamInfo = new TeamInfo();
+        teamInfo.setId("teamId");
+        teamInfo.setName("teamName");
+
+        Activity activity = MessageFactory.text("test");
+        ChannelAccount from = new ChannelAccount();
+        from.setId("userId");
+        from.setName("userName");
+        from.setAadObjectId("aadId");
+        activity.setFrom(from);
+        Attachment attachment = new Attachment();
+        attachment.setContent("Hello World");
+        attachment.setContentType("test/attachment");
+        attachment.setName("testname");
+        activity.setAttachment(attachment);
+
+        new TestFlow(adapter).send(activity).startTest().join();
+
+        verify(mockTelemetryClient).trackEvent(
+            eventNameCaptor.capture(),
+            propertiesCaptor.capture()
+        );
+        List<String> eventNames = eventNameCaptor.getAllValues();
+        List<Map<String, String>> properties = propertiesCaptor.getAllValues();
+
+        Assert.assertEquals(TelemetryLoggerConstants.BOTMSGRECEIVEEVENT, eventNames.get(0));
+        String loggedAttachment = properties.get(0).get("attachments");
+        String originalAttachment = Serialization.toString(activity.getAttachments());
+        Assert.assertTrue(StringUtils.equals(loggedAttachment, originalAttachment));
+    }
+
 
     @Test
     public void Telemetry_LogTeamsProperties() throws JsonProcessingException {


### PR DESCRIPTION
Fixes #437 

## Description
Added code to log attachments as part of the TelemetryLoggerMiddleware.

## Specific Changes
Added code required to log attachments as part of the information logged if logPersonalInformation is set to true.

## Testing
Added unit test to check that attachments are logged.