### PR TITLE
Added delay to unit test

### DIFF
--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TranscriptMiddlewareTest.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/TranscriptMiddlewareTest.java
@@ -65,9 +65,9 @@ public class TranscriptMiddlewareTest {
             context.sendActivity("echo:" + context.getActivity().getText()).join();
             return CompletableFuture.completedFuture(null);
         }
-        ).send("foo").assertReply(
+        ).send("foo").delay(50).assertReply(
             (activity) -> Assert.assertEquals(activity.getType(), ActivityTypes.TYPING)
-        ).assertReply("echo:foo").send("bar").assertReply(
+        ).assertReply("echo:foo").send("bar").delay(50).assertReply(
             (activity) -> Assert.assertEquals(activity.getType(), ActivityTypes.TYPING)
         ).assertReply("echo:bar").startTest().join();
 


### PR DESCRIPTION
Fixes an issue with a sporadic failure on the TranscriptMiddlewareTest Transcript_LogActivites() that occurred when running the tests locally with Maven. 

## Testing
Had the test failing consistently on  my local system, 5 times out of 5 runs, after adding the delays the test ran correctly 5 times out of 5.