### PR TITLE
Add support for 429 response for temporarily unavailable on Authorization calls via MSAL.

### DIFF
--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/RetryAfterHelper.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/RetryAfterHelper.java
@@ -1,0 +1,68 @@
+package com.microsoft.bot.connector.authentication;
+
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Class that contains a helper function to process HTTP 429 Retry-After headers
+ * for the CredentialsAuthenticator. The reason to extract this was
+ * CredentialsAuthenticator is an internal class that isn't exposed except
+ * through other Authentication classes and we wanted a way to test the
+ * processing of 429 headers without building complicated test harnesses.
+ */
+public final class RetryAfterHelper {
+
+    private RetryAfterHelper() {
+
+    }
+
+    /**
+     * Process a RetryException and see if we should wait for a requested amount of
+     * time before retrying to call the authentication service again.
+     *
+     * @param header The header values to process.
+     * @param count  The count of how many times we have retried.
+     * @return A RetryParams with instructions of when or how many more times to
+     *         retry.
+     */
+    public static RetryParams processRetry(List<String> header, Integer count) {
+        if (header == null || header.size() == 0) {
+            return RetryParams.defaultBackOff(++count);
+        } else {
+            String headerString = header.get(0);
+            if (StringUtils.isNotBlank(headerString)) {
+                // see if it matches a numeric value
+                if (headerString.matches("^[0-9]+\\.?0*$")) {
+                    headerString = headerString.replaceAll("\\.0*$", "");
+                    Duration delay = Duration.ofSeconds(Long.parseLong(headerString));
+                    return new RetryParams(delay.toMillis());
+                } else {
+                    // check to see if it's a RFC_1123 format Date/Time
+                    DateTimeFormatter gmtFormat = DateTimeFormatter.RFC_1123_DATE_TIME;
+                    try {
+                        ZonedDateTime zoned = ZonedDateTime.parse(headerString, gmtFormat);
+                        if (zoned != null) {
+                            ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+                            long waitMillis = zoned.toInstant().toEpochMilli() - now.toInstant().toEpochMilli();
+                            if (waitMillis > 0) {
+                                return new RetryParams(waitMillis);
+                            } else {
+                                return RetryParams.defaultBackOff(++count);
+                            }
+                        }
+                    } catch (DateTimeParseException ex) {
+                        return RetryParams.defaultBackOff(++count);
+                    }
+                }
+            }
+        }
+        return RetryParams.defaultBackOff(++count);
+    }
+
+}

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/RetryAfterHelperTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/RetryAfterHelperTests.java
@@ -1,0 +1,95 @@
+package com.microsoft.bot.connector;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.microsoft.aad.msal4j.MsalException;
+import com.microsoft.aad.msal4j.MsalServiceException;
+import com.microsoft.bot.connector.authentication.RetryAfterHelper;
+import com.microsoft.bot.connector.authentication.RetryException;
+import com.microsoft.bot.connector.authentication.RetryParams;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RetryAfterHelperTests {
+
+    @Test
+    public void TestRetryIncrement() {
+        RetryParams result = RetryAfterHelper.processRetry(new ArrayList<String>(), 8);
+        Assert.assertTrue(result.getShouldRetry());
+        result = RetryAfterHelper.processRetry(new ArrayList<String>(), 9);
+        Assert.assertFalse(result.getShouldRetry());
+    }
+
+    @Test
+    public void TestRetryDelaySeconds() {
+        List<String> headers = new ArrayList<String>();
+        headers.add("10");
+        RetryParams result = RetryAfterHelper.processRetry(headers, 1);
+        Assert.assertEquals(result.getRetryAfter(), 10000);
+    }
+
+    @Test
+    public void TestRetryDelayRFC1123Date() {
+        Instant instant = Instant.now().plusSeconds(5);
+        ZonedDateTime dateTime = instant.atZone(ZoneId.of("UTC"));
+        String dateTimeString = dateTime.format(DateTimeFormatter.RFC_1123_DATE_TIME);
+        List<String> headers = new ArrayList<String>();
+        headers.add(dateTimeString);
+        RetryParams result = RetryAfterHelper.processRetry(headers, 1);
+        Assert.assertTrue(result.getShouldRetry());
+        Assert.assertTrue(result.getRetryAfter() > 0);
+    }
+
+    @Test
+    public void TestRetryDelayRFC1123DateInPast() {
+        Instant instant = Instant.now().plusSeconds(-5);
+        ZonedDateTime dateTime = instant.atZone(ZoneId.of("UTC"));
+        String dateTimeString = dateTime.format(DateTimeFormatter.RFC_1123_DATE_TIME);
+        List<String> headers = new ArrayList<String>();
+        headers.add(dateTimeString);
+        RetryParams result = RetryAfterHelper.processRetry(headers, 1);
+        Assert.assertTrue(result.getShouldRetry());
+        // default is 50, so since the time was in the past we should be seeing the default 50 here.
+        Assert.assertTrue(result.getRetryAfter() == 50);
+    }
+
+
+    @Test
+    public void TestRetryDelayRFC1123DateEmpty() {
+        List<String> headers = new ArrayList<String>();
+        headers.add("");
+        RetryParams result = RetryAfterHelper.processRetry(headers, 1);
+        Assert.assertTrue(result.getShouldRetry());
+        // default is 50, so since the time was in the past we should be seeing the default 50 here.
+        Assert.assertTrue(result.getRetryAfter() == 50);
+    }
+
+    @Test
+    public void TestRetryDelayRFC1123DateNull() {
+        List<String> headers = new ArrayList<String>();
+        headers.add(null);
+        RetryParams result = RetryAfterHelper.processRetry(headers, 1);
+        Assert.assertTrue(result.getShouldRetry());
+        // default is 50, so since the time was in the past we should be seeing the default 50 here.
+        Assert.assertTrue(result.getRetryAfter() == 50);
+    }
+
+    @Test
+    public void TestRetryDelayRFC1123NeaderNull() {
+        RetryParams result = RetryAfterHelper.processRetry(null, 1);
+        Assert.assertTrue(result.getShouldRetry());
+        // default is 50, so since the time was in the past we should be seeing the default 50 here.
+        Assert.assertTrue(result.getRetryAfter() == 50);
+    }
+
+}


### PR DESCRIPTION
Fixes #507 

## Description
Added code to check the result of the call to MSAL to authenticate and if a Retry-After header is present it will decode the <http-date> or <delay-seconds> and return the appropriate RetryParams to the Retry logic.

## Specific Changes
Decode the HTTP 429 response header to see if it provides a number of milliseconds, or a RFC1123 formatted date as to how long to wait before having the Retry logic retry the authentication call.

## Testing
Unit tests was written to test the header decode logic that was added.