### PR TITLE
Updates to SetSpeakMiddleware

### DIFF
--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/SetSpeakMiddleware.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/SetSpeakMiddleware.java
@@ -25,24 +25,17 @@ public class SetSpeakMiddleware implements Middleware {
 
     private final String voiceName;
     private final boolean fallbackToTextForSpeak;
-    private final String lang;
 
     /**
      * Initializes a new instance of the {@link SetSpeakMiddleware} class.
      *
      * @param voiceName              The SSML voice name attribute value.
-     * @param lang                   The xml:lang value.
      * @param fallbackToTextForSpeak true if an empt Activity.Speak is populated
      *                               with Activity.getText().
      */
-    public SetSpeakMiddleware(String voiceName, String lang, boolean fallbackToTextForSpeak) {
+    public SetSpeakMiddleware(String voiceName, boolean fallbackToTextForSpeak) {
         this.voiceName = voiceName;
         this.fallbackToTextForSpeak = fallbackToTextForSpeak;
-        if (lang == null) {
-            throw new IllegalArgumentException("lang cannot be null.");
-        } else {
-            this.lang = lang;
-        }
     }
 
     /**
@@ -73,10 +66,11 @@ public class SetSpeakMiddleware implements Middleware {
                                 activity.setSpeak(
                                         String.format("<voice name='%s'>%s</voice>", voiceName, activity.getSpeak()));
                             }
-
                             activity.setSpeak(String
                                     .format("<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' "
-                                            + "xml:lang='%s'>%s</speak>", lang, activity.getSpeak()));
+                                            + "xml:lang='%s'>%s</speak>",
+                                            activity.getLocale() != null ? activity.getLocale() : "en-US",
+                                            activity.getSpeak()));
                         }
                     }
                 }

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/SetSpeakMiddlewareTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/SetSpeakMiddlewareTests.java
@@ -17,15 +17,9 @@ import org.junit.Test;
 public class SetSpeakMiddlewareTests {
 
     @Test
-    public void ConstructorValidation() {
-        // no 'lang'
-        Assert.assertThrows(IllegalArgumentException.class, () -> new SetSpeakMiddleware("voice", null, false));
-    }
-
-    @Test
     public void NoFallback() {
         TestAdapter adapter = new TestAdapter(createConversation("NoFallback"))
-                .use(new SetSpeakMiddleware("male", "en-us", false));
+                .use(new SetSpeakMiddleware("male", false));
 
         new TestFlow(adapter, turnContext -> {
             Activity activity = MessageFactory.text("OK");
@@ -43,7 +37,7 @@ public class SetSpeakMiddlewareTests {
     @Test
     public void FallbackNullSpeak() {
         TestAdapter adapter = new TestAdapter(createConversation("NoFallback"))
-                .use(new SetSpeakMiddleware("male", "en-us", true));
+                .use(new SetSpeakMiddleware("male", true));
 
         new TestFlow(adapter, turnContext -> {
             Activity activity = MessageFactory.text("OK");
@@ -61,7 +55,7 @@ public class SetSpeakMiddlewareTests {
     @Test
     public void FallbackWithSpeak() {
         TestAdapter adapter = new TestAdapter(createConversation("Fallback"))
-                .use(new SetSpeakMiddleware("male", "en-us", true));
+                .use(new SetSpeakMiddleware("male", true));
 
         new TestFlow(adapter, turnContext -> {
             Activity activity = MessageFactory.text("OK");
@@ -93,7 +87,7 @@ public class SetSpeakMiddlewareTests {
     // Voice instanceof added to Speak property.
     public void AddVoice(String channelId) {
         TestAdapter adapter = new TestAdapter(createConversation("Fallback", channelId))
-                .use(new SetSpeakMiddleware("male", "en-us", true));
+                .use(new SetSpeakMiddleware("male", true));
 
         new TestFlow(adapter, turnContext -> {
             Activity activity = MessageFactory.text("OK");
@@ -119,14 +113,14 @@ public class SetSpeakMiddlewareTests {
 
     @Test
     public void AddNoVoiceTelephony() {
-        AddNoVoice("telephony");
+        AddNoVoice(Channels.TELEPHONY);
     }
 
 
     // With no 'voice' specified, the Speak property instanceof unchanged.
     public void AddNoVoice(String channelId) {
         TestAdapter adapter = new TestAdapter(createConversation("Fallback", channelId))
-                .use(new SetSpeakMiddleware(null, "en-us", true));
+                .use(new SetSpeakMiddleware(null, true));
 
         new TestFlow(adapter, turnContext -> {
             Activity activity = MessageFactory.text("OK");

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/Channels.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/Channels.java
@@ -100,4 +100,9 @@ public final class Channels {
      * Test channel.
      */
     public static final String TEST = "test";
+
+    /**
+     * Telephony channel.
+     */
+    public static final String TELEPHONY = "telephony";
 }


### PR DESCRIPTION
Fixes #1122 

## Description
Updated SetSpeakMiddleware to set language based on locale of the Activity and not as a parameter during construction of the class.

## Specific Changes
Modified constructor to no longer allow the language to be passed as a parameter as this value will now be set based on the locale of the Activity, and if that isn't set it will be set to a default of "en-US".

## Testing
Unit tests were modified to reflect the new changes and run with success.