### PR TITLE
Removed references to TrustServiceUrl

### DIFF
--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotFrameworkAdapter.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/BotFrameworkAdapter.java
@@ -379,21 +379,11 @@ public class BotFrameworkAdapter extends BotAdapter
             context.getTurnState().add(BOT_IDENTITY_KEY, claimsIdentity);
             context.getTurnState().add(OAUTH_SCOPE_KEY, audience);
 
-            String appIdFromClaims = JwtTokenValidation.getAppIdFromClaims(claimsIdentity.claims());
-            return credentialProvider.isValidAppId(appIdFromClaims).thenCompose(isValidAppId -> {
-                // If we receive a valid app id in the incoming token claims, add the
-                // channel service URL to the trusted services list so we can send messages
-                // back.
-                if (!StringUtils.isEmpty(appIdFromClaims) && isValidAppId) {
-                    AppCredentials.trustServiceUrl(reference.getServiceUrl());
-                }
-
-                return createConnectorClient(reference.getServiceUrl(), claimsIdentity, audience)
-                    .thenCompose(connectorClient -> {
-                        context.getTurnState().add(CONNECTOR_CLIENT_KEY, connectorClient);
-                        return runPipeline(context, callback);
-                    });
-            });
+            return createConnectorClient(reference.getServiceUrl(), claimsIdentity, audience)
+                .thenCompose(connectorClient -> {
+                    context.getTurnState().add(CONNECTOR_CLIENT_KEY, connectorClient);
+                    return runPipeline(context, callback);
+                });
         } catch (Exception e) {
             pipelineResult.completeExceptionally(e);
         }

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/JwtTokenValidation.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/authentication/JwtTokenValidation.java
@@ -98,13 +98,7 @@ public final class JwtTokenValidation {
         return JwtTokenValidation.validateAuthHeader(
             authHeader, credentials, channelProvider, activity.getChannelId(),
             activity.getServiceUrl(), authConfig
-        )
-
-            .thenApply(identity -> {
-                // On the standard Auth path, we need to trust the URL that was incoming.
-                MicrosoftAppCredentials.trustServiceUrl(activity.getServiceUrl());
-                return identity;
-            });
+        );
     }
 
     /**

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/JwtTokenValidationTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/JwtTokenValidationTests.java
@@ -156,24 +156,6 @@ public class JwtTokenValidationTests {
     }
 
     /**
-     * Tests with a valid Token and service url; and ensures that Service url is added to Trusted service url list.
-     */
-    @Test
-    public void ChannelMsaHeaderValidServiceUrlShouldBeTrusted() throws IOException, ExecutionException, InterruptedException {
-        String header = getHeaderToken();
-        CredentialProvider credentials = new SimpleCredentialProvider(APPID, "");
-        Activity activity = new Activity(ActivityTypes.MESSAGE);
-        activity.setServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/");
-        JwtTokenValidation.authenticateRequest(
-            activity,
-            header,
-            credentials,
-            new SimpleChannelProvider()).join();
-
-        Assert.assertTrue(MicrosoftAppCredentials.isTrustedServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/"));
-    }
-
-    /**
      * Tests with a valid Token and invalid service url; and ensures that Service url is NOT added to Trusted service url list.
      */
     @Test
@@ -192,7 +174,6 @@ public class JwtTokenValidationTests {
             Assert.fail("Should have thrown AuthenticationException");
         } catch (CompletionException e) {
             Assert.assertTrue(e.getCause() instanceof AuthenticationException);
-            Assert.assertFalse(MicrosoftAppCredentials.isTrustedServiceUrl("https://webchat.botframework.com/"));
         }
     }
 
@@ -255,26 +236,6 @@ public class JwtTokenValidationTests {
         } catch (CompletionException e) {
             Assert.assertTrue(e.getCause() instanceof AuthenticationException);
         }
-
-        Assert.assertFalse(MicrosoftAppCredentials.isTrustedServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/"));
-    }
-
-    /**
-     * Tests with no authentication header and makes sure the service URL is not added to the trusted list.
-     */
-    @Test
-    public void ChannelAuthenticationDisabledServiceUrlShouldNotBeTrusted() throws ExecutionException, InterruptedException {
-        String header = "";
-        CredentialProvider credentials = new SimpleCredentialProvider("", "");
-
-        Activity activity = new Activity(ActivityTypes.MESSAGE);
-        activity.setServiceUrl("https://webchat.botframework.com/");
-        ClaimsIdentity identity = JwtTokenValidation.authenticateRequest(
-            activity,
-            header,
-            credentials,
-            new SimpleChannelProvider()).join();
-        Assert.assertFalse(MicrosoftAppCredentials.isTrustedServiceUrl("https://webchat.botframework.com/"));
     }
 
     @Test

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/MicrosoftAppCredentialsTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/connector/MicrosoftAppCredentialsTests.java
@@ -14,27 +14,6 @@ import java.net.URL;
 import java.time.LocalDateTime;
 
 public class MicrosoftAppCredentialsTests {
-    @Test
-    public void ValidUrlTrusted() {
-        MicrosoftAppCredentials.trustServiceUrl("https://goodurl.com");
-        Assert.assertTrue(MicrosoftAppCredentials.isTrustedServiceUrl("https://goodurl.com"));
-    }
-
-    @Test
-    public void InvalidUrlTrusted() {
-        MicrosoftAppCredentials.trustServiceUrl("badurl");
-        Assert.assertFalse(MicrosoftAppCredentials.isTrustedServiceUrl("badurl"));
-    }
-
-    @Test
-    public void TrustedUrlExpiration() throws InterruptedException {
-        // There is a +5 minute window for an expired url
-        MicrosoftAppCredentials.trustServiceUrl("https://goodurl.com", LocalDateTime.now().minusMinutes(6));
-        Assert.assertFalse(MicrosoftAppCredentials.isTrustedServiceUrl("https://goodurl.com"));
-
-        MicrosoftAppCredentials.trustServiceUrl("https://goodurl.com", LocalDateTime.now().minusMinutes(4));
-        Assert.assertTrue(MicrosoftAppCredentials.isTrustedServiceUrl("https://goodurl.com"));
-    }
 
     @Test
     public void ValidateAuthEndpoint() {


### PR DESCRIPTION
Fixes #946 
## Description
Removed references to TrustServiceUrl to match C# code updates.

## Specific Changes
Removed one place that was checking TrustServiceUrl in AppCredentials and all places that were adding URLs to this list. Removed the list and all static values that were part of the list. The only change of any effect will be we no longer check in AppCredentials if a URL is in the list in shouldSetToken and will just return true where in the past we checked to see if the URL was in the trusted list.

## Testing
All unit tests were updated and run to validate this change. 