### PR TITLE
Removed obsolete DialogManager property.

### DIFF
--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/DialogContext.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/DialogContext.java
@@ -167,14 +167,6 @@ public class DialogContext {
     }
 
     /**
-     * Gets the current DialogManager for this dialogContext.
-     * @return The root dialogManager that was used to create this dialog context chain.
-     */
-    public DialogManager getDialogManager() {
-        return getContext().getTurnState().get(DialogManager.class);
-    }
-
-    /**
      * Starts a new dialog and pushes it onto the dialog stack.
      * @param dialogId ID of the dialog to start.
      * @return If the task is successful, the result indicates whether the dialog is still


### PR DESCRIPTION
Fixes #1124 

## Description
Rather than mark as obsolete to preserve backward compatibility I removed the DialogManager property from the DialogContext, it's likely better to do this before the SDK is RTM than to mark it and remove it later.

## Specific Changes
Removed DialogManager property from the DialogContext.

## Testing
All unit tests were run successfully after the removal of the property. All samples were searched to ensure that none of them had references to it as well.