### PR TITLE
Implemented ResumeDialog in Skills

### DIFF
--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/skills/SkillConversationIdFactory.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/skills/SkillConversationIdFactory.java
@@ -5,6 +5,7 @@ package com.microsoft.bot.builder.skills;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import com.microsoft.bot.builder.Storage;
@@ -51,9 +52,7 @@ public class SkillConversationIdFactory extends SkillConversationIdFactoryBase {
             Async.completeExceptionally(new IllegalArgumentException("options cannot be null."));
         }
         ConversationReference conversationReference = options.getActivity().getConversationReference();
-        String skillConversationId = String.format("%s-%s-%s-skillconvo",
-                conversationReference.getConversation().getId(), options.getBotFrameworkSkill().getId(),
-                conversationReference.getChannelId());
+        String skillConversationId = UUID.randomUUID().toString();
 
         SkillConversationReference skillConversationReference = new SkillConversationReference();
         skillConversationReference.setConversationReference(conversationReference);

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/SkillConversationIdFactoryTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/SkillConversationIdFactoryTests.java
@@ -64,6 +64,34 @@ public class SkillConversationIdFactoryTests {
         Assert.assertNull(deletedConversationReference);
     }
 
+    @Test
+    public void IdIsUniqueEachTime() {
+        ConversationReference conversationReference = buildConversationReference();
+
+        // Create skill conversation
+        SkillConversationIdFactoryOptions options1 = new SkillConversationIdFactoryOptions();
+        options1.setActivity(buildMessageActivity(conversationReference));
+        options1.setBotFrameworkSkill(buildBotFrameworkSkill());
+        options1.setFromBotId(botId);
+        options1.setFromBotOAuthScope(botId);
+
+        String firstId = skillConversationIdFactory.createSkillConversationId(options1).join();
+
+
+        SkillConversationIdFactoryOptions options2 = new SkillConversationIdFactoryOptions();
+        options2.setActivity(buildMessageActivity(conversationReference));
+        options2.setBotFrameworkSkill(buildBotFrameworkSkill());
+        options2.setFromBotId(botId);
+        options2.setFromBotOAuthScope(botId);
+
+        String secondId = skillConversationIdFactory.createSkillConversationId(options2).join();
+
+        // Ensure that we get a different conversationId each time we call CreateSkillConversationIdAsync
+        Assert.assertNotEquals(firstId, secondId);
+    }
+
+
+
     private static ConversationReference buildConversationReference() {
         ConversationReference conversationReference = new ConversationReference();
         conversationReference.setConversation(new ConversationAccount(UUID.randomUUID().toString()));

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/SkillDialog.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/SkillDialog.java
@@ -116,6 +116,14 @@ public class SkillDialog extends Dialog {
      */
     @Override
     public CompletableFuture<DialogTurnResult> continueDialog(DialogContext dc) {
+
+        Boolean interrupted = dc.getState().getValue(TurnPath.INTERRUPTED, false, Boolean.class);
+        if (interrupted) {
+            dc.getState().setValue(TurnPath.INTERRUPTED, false);
+            return resumeDialog(dc, DialogReason.END_CALLED);
+        }
+
+
         if (!onValidateActivity(dc.getContext().getActivity())) {
             return CompletableFuture.completedFuture(END_OF_TURN);
         }


### PR DESCRIPTION
Fixes #1131 

## Description
Ported parts of changes for skills that were appropriate for the Skills part of these changes The adaptive parts are not needed yet as Adaptive is not part of the Java SDK.

## Specific Changes
Changed SkillConverationIdFactory for Id generation, and updated SkillDialog to handle interruption from an adaptive dialog that might be calling a Skill.

## Testing
Added unit tests for changes to SkillConversationIdFactory to test changes in Id creation.