### PR TITLE
Update version to 4.13.0

### DIFF
--- a/Generator/generator-botbuilder-java/generators/app/templates/core/project/pom.xml
+++ b/Generator/generator-botbuilder-java/generators/app/templates/core/project/pom.xml
@@ -81,18 +81,18 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
   </dependencies>
 

--- a/libraries/bot-ai-luis-v3/pom.xml
+++ b/libraries/bot-ai-luis-v3/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-ai-qna/pom.xml
+++ b/libraries/bot-ai-qna/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-applicationinsights/pom.xml
+++ b/libraries/bot-applicationinsights/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-azure/pom.xml
+++ b/libraries/bot-azure/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-builder/pom.xml
+++ b/libraries/bot-builder/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-connector/pom.xml
+++ b/libraries/bot-connector/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-dialogs/pom.xml
+++ b/libraries/bot-dialogs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-integration-core/pom.xml
+++ b/libraries/bot-integration-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-integration-spring/pom.xml
+++ b/libraries/bot-integration-spring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-schema/pom.xml
+++ b/libraries/bot-schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.6.0-preview9</version>
+    <version>4.13.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.microsoft.bot</groupId>
   <artifactId>bot-java</artifactId>
-  <version>4.6.0-preview9</version>
+  <version>4.13.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Microsoft BotBuilder Java SDK Parent</name>

--- a/samples/02.echo-bot/pom.xml
+++ b/samples/02.echo-bot/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/03.welcome-user/pom.xml
+++ b/samples/03.welcome-user/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/05.multi-turn-prompt/pom.xml
+++ b/samples/05.multi-turn-prompt/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/06.using-cards/pom.xml
+++ b/samples/06.using-cards/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/07.using-adaptive-cards/pom.xml
+++ b/samples/07.using-adaptive-cards/pom.xml
@@ -81,19 +81,19 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-builder</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>  </dependencies>
 

--- a/samples/08.suggested-actions/pom.xml
+++ b/samples/08.suggested-actions/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/11.qnamaker/pom.xml
+++ b/samples/11.qnamaker/pom.xml
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-qna</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -87,7 +87,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/13.core-bot/pom.xml
+++ b/samples/13.core-bot/pom.xml
@@ -81,18 +81,18 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
   </dependencies>
 

--- a/samples/14.nlp-with-dispatch/pom.xml
+++ b/samples/14.nlp-with-dispatch/pom.xml
@@ -81,18 +81,18 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-qna</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
 

--- a/samples/15.handling-attachments/pom.xml
+++ b/samples/15.handling-attachments/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/16.proactive-messages/pom.xml
+++ b/samples/16.proactive-messages/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/17.multilingual-bot/pom.xml
+++ b/samples/17.multilingual-bot/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/18.bot-authentication/pom.xml
+++ b/samples/18.bot-authentication/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/19.custom-dialogs/pom.xml
+++ b/samples/19.custom-dialogs/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/21.corebot-app-insights/pom.xml
+++ b/samples/21.corebot-app-insights/pom.xml
@@ -81,23 +81,23 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-applicationinsights</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
   </dependencies>
 

--- a/samples/23.facebook-events/pom.xml
+++ b/samples/23.facebook-events/pom.xml
@@ -80,13 +80,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/24.bot-authentication-msgraph/pom.xml
+++ b/samples/24.bot-authentication-msgraph/pom.xml
@@ -86,13 +86,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/25.message-reaction/pom.xml
+++ b/samples/25.message-reaction/pom.xml
@@ -62,7 +62,7 @@
         <artifactId>junit-vintage-engine</artifactId>
         <scope>test</scope>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/40.timex-resolution/pom.xml
+++ b/samples/40.timex-resolution/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.microsoft.bot</groupId>
       <artifactId>bot-dialogs</artifactId>
-      <version>4.6.0-preview9</version>
+      <version>4.13.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/samples/43.complex-dialog/pom.xml
+++ b/samples/43.complex-dialog/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/44.prompt-users-for-input/pom.xml
+++ b/samples/44.prompt-users-for-input/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/45.state-management/pom.xml
+++ b/samples/45.state-management/pom.xml
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/46.teams-auth/pom.xml
+++ b/samples/46.teams-auth/pom.xml
@@ -87,13 +87,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/46.teams-auth/pom.xml
+++ b/samples/46.teams-auth/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/47.inspection/pom.xml
+++ b/samples/47.inspection/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/49.qnamaker-all-features/pom.xml
+++ b/samples/49.qnamaker-all-features/pom.xml
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-qna</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -87,7 +87,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/50.teams-messaging-extensions-search/pom.xml
+++ b/samples/50.teams-messaging-extensions-search/pom.xml
@@ -75,7 +75,7 @@
      <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/50.teams-messaging-extensions-search/pom.xml
+++ b/samples/50.teams-messaging-extensions-search/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/samples/51.teams-messaging-extensions-action/pom.xml
+++ b/samples/51.teams-messaging-extensions-action/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/51.teams-messaging-extensions-action/pom.xml
+++ b/samples/51.teams-messaging-extensions-action/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/52.teams-messaging-extensions-search-auth-config/pom.xml
+++ b/samples/52.teams-messaging-extensions-search-auth-config/pom.xml
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/52.teams-messaging-extensions-search-auth-config/pom.xml
+++ b/samples/52.teams-messaging-extensions-search-auth-config/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
     </dependencies>

--- a/samples/53.teams-messaging-extensions-action-preview/pom.xml
+++ b/samples/53.teams-messaging-extensions-action-preview/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/53.teams-messaging-extensions-action-preview/pom.xml
+++ b/samples/53.teams-messaging-extensions-action-preview/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/54.teams-task-module/pom.xml
+++ b/samples/54.teams-task-module/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>

--- a/samples/54.teams-task-module/pom.xml
+++ b/samples/54.teams-task-module/pom.xml
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/samples/55.teams-link-unfurling/pom.xml
+++ b/samples/55.teams-link-unfurling/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/55.teams-link-unfurling/pom.xml
+++ b/samples/55.teams-link-unfurling/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/56.teams-file-upload/pom.xml
+++ b/samples/56.teams-file-upload/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/56.teams-file-upload/pom.xml
+++ b/samples/56.teams-file-upload/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/57.teams-conversation-bot/pom.xml
+++ b/samples/57.teams-conversation-bot/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
 
       <dependency>

--- a/samples/57.teams-conversation-bot/pom.xml
+++ b/samples/57.teams-conversation-bot/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/58.teams-start-new-thread-in-channel/pom.xml
+++ b/samples/58.teams-start-new-thread-in-channel/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>

--- a/samples/58.teams-start-new-thread-in-channel/pom.xml
+++ b/samples/58.teams-start-new-thread-in-channel/pom.xml
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/samples/80.skills-simple-bot-to-bot/DialogRootBot/pom.xml
+++ b/samples/80.skills-simple-bot-to-bot/DialogRootBot/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-builder</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/80.skills-simple-bot-to-bot/DialogSkillBot/pom.xml
+++ b/samples/80.skills-simple-bot-to-bot/DialogSkillBot/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/81.skills-skilldialog/dialog-root-bot/pom.xml
+++ b/samples/81.skills-skilldialog/dialog-root-bot/pom.xml
@@ -81,19 +81,19 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-builder</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>  </dependencies>
 

--- a/samples/81.skills-skilldialog/dialog-skill-bot/pom.xml
+++ b/samples/81.skills-skilldialog/dialog-skill-bot/pom.xml
@@ -81,19 +81,19 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   <profiles>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.microsoft.bot</groupId>
   <artifactId>bot-java</artifactId>
-  <version>4.6.0-preview9</version>
+  <version>4.13.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Microsoft BotBuilder Java SDK Parent</name>

--- a/samples/servlet-echo/pom.xml
+++ b/samples/servlet-echo/pom.xml
@@ -87,7 +87,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-core</artifactId>
-        <version>4.6.0-preview9</version>
+        <version>4.13.0-SNAPSHOT</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
Fixes #1102 

## Description
Updated POM files to version 4.1.3.0-SNAPSHOT. Also updated the version for log4j core of the samples that were using it in that it had a known vulnerability.

## Testing
Full compile, unit test, and sample compile.