### PR TITLE
Support for Recognizer tests on MacOS.

### DIFF
--- a/libraries/bot-dialogs/src/test/java/com/microsoft/recognizers/text/tests/AbstractTest.java
+++ b/libraries/bot-dialogs/src/test/java/com/microsoft/recognizers/text/tests/AbstractTest.java
@@ -26,7 +26,7 @@ import java.util.stream.IntStream;
 @RunWith(Parameterized.class)
 public abstract class AbstractTest {
 
-    private static final String SpecsPath = "Specs/..";
+    private static final String SpecsPath = "./src/test/java/com/microsoft/recognizers/text/tests/Specs/..";
 
     private static final List<String> SupportedCultures = Arrays.asList("English", "Spanish", "Portuguese", "French", "German", "Chinese");
 


### PR DESCRIPTION
Fixes #1172 

## Description
Added path that works for both MacOS and Windows to the AbstractTest class.

## Specific Changes
Updated path to include full path from directory the unit tests run from.

## Testing
All unit tests were executed on both Windows and MacOS to make sure the change worked on both platforms.