### PR TITLE
Updated pom.xml to enable Jacoco output

### DIFF
--- a/libraries/bot-dialogs/pom.xml
+++ b/libraries/bot-dialogs/pom.xml
@@ -164,7 +164,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-Dfile.encoding=UTF-8</argLine>
+          <argLine>${argLine} -Dfile.encoding=UTF-8</argLine>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Fixes #1174 

Updated pom.xml to pass additional arguments through which will re-enable the Jacoco output from the Dialogs project.

Unit tests were run and checked that the tests both run, and the Jacoco output is now being created.