### PR TITLE
[QnA] Fix MultiTurnPrompt QnA conversation

### DIFF
--- a/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/dialogs/QnAMakerDialog.java
+++ b/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/dialogs/QnAMakerDialog.java
@@ -975,7 +975,12 @@ public class QnAMakerDialog extends WaterfallDialog {
             QueryResult answer = response.get(0);
 
             if (answer.getContext() != null && answer.getContext().getPrompts().length > 0) {
-                Map<String, Integer> previousContextData = ObjectPath.getPathValue(stepContext.getActiveDialog().getState(), QNA_CONTEXT_DATA, Map.class, new HashMap<>());
+                Map<String, Integer> previousContextData =
+                    ObjectPath.getPathValue(
+                        stepContext.getActiveDialog().getState(),
+                        QNA_CONTEXT_DATA,
+                        Map.class,
+                        new HashMap<>());
                 for (QnAMakerPrompt prompt : answer.getContext().getPrompts()) {
                     previousContextData.put(prompt.getDisplayText(), prompt.getQnaId());
                 }

--- a/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/dialogs/QnAMakerDialog.java
+++ b/libraries/bot-ai-qna/src/main/java/com/microsoft/bot/ai/qna/dialogs/QnAMakerDialog.java
@@ -854,13 +854,9 @@ public class QnAMakerDialog extends WaterfallDialog {
 
         // Calling QnAMaker to get response.
         return this.getQnAMakerClient(stepContext).thenApply(qnaMakerClient -> {
-            QueryResults response =
-                (QueryResults) stepContext.getState().get(String.format("turn.qnaresult%s", this.hashCode()));
-            if (response == null) {
-                response = qnaMakerClient
+            QueryResults response = qnaMakerClient
                     .getAnswersRaw(stepContext.getContext(), dialogOptions.getQnAMakerOptions(), null, null)
                     .join();
-            }
 
             // Resetting previous query.
             Integer previousQnAId = -1;
@@ -979,9 +975,7 @@ public class QnAMakerDialog extends WaterfallDialog {
             QueryResult answer = response.get(0);
 
             if (answer.getContext() != null && answer.getContext().getPrompts().length > 0) {
-                Map<String, Integer> previousContextData =
-                    ObjectPath.getPathValue(stepContext.getActiveDialog().getState(), QNA_CONTEXT_DATA, Map.class);
-
+                Map<String, Integer> previousContextData = ObjectPath.getPathValue(stepContext.getActiveDialog().getState(), QNA_CONTEXT_DATA, Map.class, new HashMap<>());
                 for (QnAMakerPrompt prompt : answer.getContext().getPrompts()) {
                     previousContextData.put(prompt.getDisplayText(), prompt.getQnaId());
                 }


### PR DESCRIPTION
Related to #1166

## Description
When the MultiTurnPrompt QnA conversation is configured and executed in a Java sample (e.g. [49.qnamaker-all-features](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/java_springboot/49.qnamaker-all-features)), the conversation has an infinite loop.

## Specific Changes
- Get the response from the `qnaMakerClient` (like [JS](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder-ai/src/qnaMakerDialog.ts#L680))
- Obtain a default empty dictionary when the `QNA_CONTEXT_DATA` is not present in the state of the active dialog (like [C#](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs#L735))

## Testing
_MultiTurnPrompt working as expected_
![image](https://user-images.githubusercontent.com/11904023/117815559-fc430f80-b23b-11eb-8be4-3e22bfec1a0a.png)

![image](https://user-images.githubusercontent.com/11904023/117815564-fea56980-b23b-11eb-926e-f8b7572b90f4.png)
