### PR TITLE
Move file.encoding to be a property

### DIFF
--- a/libraries/bot-dialogs/pom.xml
+++ b/libraries/bot-dialogs/pom.xml
@@ -162,15 +162,4 @@
       </plugin>
     </plugins>
   </reporting>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>${argLine} -Dfile.encoding=UTF-8</argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <checkstyle.version>3.1.2</checkstyle.version>
     <pmd.version>3.14.0</pmd.version>
     <exclude.tests>%regex[.*recognizers.*]</exclude.tests>
+    <argLine>-Dfile.encoding=UTF-8</argLine>
     <!-- <repo.id>MyGet</repo.id> -->
     <!-- <repo.url>https://botbuilder.myget.org/F/botbuilder-v4-java-daily/maven/</repo.url> -->
     <!-- <repo.id>ossrh</repo.id> -->


### PR DESCRIPTION
Fixes #1278 

## Description
Moved file.encoding in pom.xml from surefire plug in in dialogs pom.xml file to the parent pom.xml file and now set it as a property. This allows both the recognizer tests to run as well as produce Jacoco output

## Testing
Ran build locally and verified that the Jacoco output was created as well as the recognizer unit tests were executed.