### PR TITLE
Fixed incorrect cast error.

### DIFF
--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/OAuthPrompt.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/prompts/OAuthPrompt.java
@@ -266,7 +266,7 @@ public class OAuthPrompt extends Dialog {
             Object tokenResponseObject = turnContext.getActivity().getValue();
             TokenResponse token = null;
             if (tokenResponseObject != null) {
-                token = (TokenResponse) tokenResponseObject;
+                token = Serialization.getAs(tokenResponseObject, TokenResponse.class);
             }
             result.setSucceeded(true);
             result.setValue(token);


### PR DESCRIPTION
Fixes #1286 

## Description
Sample 18.bot-authentication was failing when using the bot framework emulator due to a cast that was being made in the OAuthPrompt that wasn't correct. This caused an exception to occur that stopped the dialog result from being properly handled so the user was logged in, but the subsequent action in the waterfall dialog was not executed as expected in the sample.

## Specific Changes
Corrected the cast to corrected deserialize the incoming data by using the Serialization library.

## Testing
Tested the sample code using this change both locally and as deployed in Azure with both the bot framework emulator and web chat to make sure the results were consistent.