### PR TITLE
Extend maxTimeout for TranscriptStoreTests

### DIFF
--- a/libraries/bot-azure/src/test/java/com/microsoft/bot/azure/TranscriptStoreTests.java
+++ b/libraries/bot-azure/src/test/java/com/microsoft/bot/azure/TranscriptStoreTests.java
@@ -493,7 +493,7 @@ public class TranscriptStoreTests {
             Integer expectedLength, Integer maxTimeout) throws TimeoutException {
         TranscriptStore transcriptStore = getTranscriptStore();
         if (maxTimeout == null) {
-            maxTimeout = 5000;
+            maxTimeout = 10000;
         }
 
         PagedResult<Activity> pagedResult = null;


### PR DESCRIPTION
Fixes #1303 

## Description
Increase maxTimeout default value for TranscriptStoreTests to match C# updates

## Specific Changes
Updated maxTimeout to 10000 from 5000.

## Testing
Unit tests were run to validate changes.