### PR TITLE
Update Activity and unit tests

### DIFF
--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/adapters/TestAdapter.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/adapters/TestAdapter.java
@@ -193,7 +193,10 @@ public class TestAdapter extends BotAdapter implements UserTokenProvider {
                 // ready for next reply
                 if (activity.getType() == null)
                     activity.setType(ActivityTypes.MESSAGE);
-                activity.setChannelId(conversationReference().getChannelId());
+
+                if (activity.getChannelId() == null) {
+                    activity.setChannelId(conversationReference().getChannelId());
+                }
 
                 if (activity.getFrom() == null || StringUtils.equalsIgnoreCase(activity.getFrom().getId(), "unknown")
                         || activity.getFrom().getRole() == RoleTypes.BOT) {

--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
@@ -1316,7 +1316,14 @@ public class Activity {
                 .setRecipient(new ChannelAccount(this.getFrom().getId(), this.getFrom().getName()));
         }
 
-        reply.setReplyToId(this.getId());
+        if (!StringUtils.equalsIgnoreCase(this.getType(), ActivityTypes.CONVERSATION_UPDATE)
+            || !StringUtils.equalsIgnoreCase(this.getChannelId(), "directline")
+            && !StringUtils.equalsIgnoreCase(this.getChannelId(), "webchat")) {
+                reply.replyToId = this.getId();
+        } else {
+            reply.replyToId = null;
+        }
+
         reply.setServiceUrl(this.getServiceUrl());
         reply.setChannelId(this.getChannelId());
 
@@ -1382,7 +1389,14 @@ public class Activity {
                 .setRecipient(new ChannelAccount(this.getFrom().getId(), this.getFrom().getName()));
         }
 
-        result.setReplyToId(this.getId());
+        if (!StringUtils.equalsIgnoreCase(this.getType(), ActivityTypes.CONVERSATION_UPDATE)
+            || !StringUtils.equalsIgnoreCase(this.getChannelId(), "directline")
+                && !StringUtils.equalsIgnoreCase(this.getChannelId(), "webchat")) {
+            result.replyToId = this.getId();
+        } else {
+            result.replyToId = null;
+        }
+
         result.setServiceUrl(this.getServiceUrl());
         result.setChannelId(this.getChannelId());
 
@@ -1503,7 +1517,14 @@ public class Activity {
     @JsonIgnore
     public ConversationReference getConversationReference() {
         ConversationReference conversationReference = new ConversationReference();
-        conversationReference.setActivityId(getId());
+        if (!StringUtils.equalsIgnoreCase(this.getType(), ActivityTypes.CONVERSATION_UPDATE)
+            || !StringUtils.equalsIgnoreCase(this.getChannelId(), "directline")
+                && !StringUtils.equalsIgnoreCase(this.getChannelId(), "webchat")) {
+                conversationReference.setActivityId(this.getId());
+        } else {
+            conversationReference.setActivityId(null);
+        }
+
         conversationReference.setUser(getFrom());
         conversationReference.setBot(getRecipient());
         conversationReference.setConversation(getConversation());

--- a/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
+++ b/libraries/bot-schema/src/test/java/com/microsoft/bot/schema/ActivityTest.java
@@ -34,6 +34,11 @@ public class ActivityTest {
         Assert.assertEquals(activity.getLocale(), conversationReference.getLocale());
         Assert.assertEquals(activity.getChannelId(), conversationReference.getChannelId());
         Assert.assertEquals(activity.getServiceUrl(), conversationReference.getServiceUrl());
+
+        activity.setType(ActivityTypes.CONVERSATION_UPDATE);
+        conversationReference = activity.getConversationReference();
+        Assert.assertNull(conversationReference.getActivityId());
+
     }
 
     @Test
@@ -229,7 +234,7 @@ public class ActivityTest {
         activity.setFrom(account1);
         activity.setRecipient(account2);
         activity.setConversation(conversationAccount);
-        activity.setChannelId("ChannelId123");
+        activity.setChannelId("directline");
         // Intentionally oddly-cased to check that it isn't defaulted somewhere, but
         // tests stay in English
         activity.setLocale("en-uS");
@@ -699,6 +704,22 @@ public class ActivityTest {
         Activity activity = createActivity();
         activity.setEntities(null);
         Assert.assertTrue(activity.getMentions() != null);
+    }
+
+    @Test
+    public void CreateTraceForConversationUpdateActivity() {
+        Activity activity = createActivity();
+        activity.setType(ActivityTypes.CONVERSATION_UPDATE);
+        Activity trace = activity.createTrace("test");
+        Assert.assertNull(trace.getReplyToId());
+    }
+
+    @Test
+    public void CreateReplyForConversationUpdateActivity() {
+        Activity activity = createActivity();
+        activity.setType(ActivityTypes.CONVERSATION_UPDATE);
+        Activity reply = activity.createReply("test");
+        Assert.assertNull(reply.getReplyToId());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1223 

## Description
Updated Activity and ActivityTests to follow C# code fixes for issues fixed in C# number 5313.

## Specific Changes
Added conditional to return null for replyToId and activityId in cases where the ActivityTpe is not CONVERSATION_UPDATE or the channelId is not directline and webchat

## Testing
Added unit tests as in C# to test new functionality.