### PR TITLE
Bruce/jsonsmartvulnerabilityfix9 24

### DIFF
--- a/libraries/bot-connector/pom.xml
+++ b/libraries/bot-connector/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>msal4j</artifactId>
-      <version>1.8.1</version>
+      <version>1.10.1</version>
     </dependency>
 
     <dependency>

--- a/libraries/bot-integration-spring/pom.xml
+++ b/libraries/bot-integration-spring/pom.xml
@@ -56,28 +56,28 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.3.1</version>
+      <version>5.3.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>5.3.1</version>
+      <version>5.3.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.9</version>
       <scope>compile</scope>
     </dependency>
 

--- a/libraries/bot-integration-spring/pom.xml
+++ b/libraries/bot-integration-spring/pom.xml
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.4.9</version>
+      <version>2.4.11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>2.4.9</version>
+      <version>2.4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,11 @@
         <artifactId>guava</artifactId>
         <version>30.1-jre</version>
       </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>2.4.7</version>
+      </dependency>
 
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Fixes #1324

## Description
Governed repositories microsoft/BotBuilder-Samples main CVE-2021-27568
https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/4872890?typeId=4354877

BotBuilder-Generator-Java-daily/269661: CVE-2021-27568|net.minidev:json-smart 2.3|Critical
An issue was discovered in netplex json-smart-v1 through 2015-10-23 and json-smart-v2 through 2.4. An exception is thrown from a function, but it is not caught, as demonstrated by NumberFormatException. When it is not caught, it may cause programs using the library to crash or expose sensitive information.

Recommendation: Upgrade net.minidev:json-smart from 2.3 to 2.4.1

## Specific Changes
For most projects, upgraded dependencies whose dependency was json-smart 2.3.

Version bumping did not work in project bot-integration-spring, so I added a json-smart version spec that matched the other projects to dependencyManagement in the parent pom.
