### PR TITLE
Fix dir workspace to run always

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ libraries/swagger/generated
 /.vs/ProjectSettings.json
 /.vs/botbuilder-java/v16/TestStore/0/000.testlog
 /.vs/botbuilder-java/v16/TestStore/0/testlog.manifest
+/.vs/VSWorkspaceState.json

--- a/pipelines/BotBuilder-Java-4.0-daily.yml
+++ b/pipelines/BotBuilder-Java-4.0-daily.yml
@@ -192,4 +192,6 @@ jobs:
         pushd ..;
         Get-ChildItem -Recurse -Force;
     displayName: Dir workspace
+    continueOnError: true
+    condition: succeededOrFailed()
 ...


### PR DESCRIPTION
Fixes #minor

## Description
Dir workspace is a diagnostic that must run when the build fails. This fixes it so it does.
