### PR TITLE
fix: Component Governance: WS-2020-0408 netty-handler

### DIFF
--- a/libraries/bot-azure/pom.xml
+++ b/libraries/bot-azure/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-queue</artifactId>
-      <version>12.8.0</version>
+      <version>12.11.0</version>
     </dependency>
 
     <dependency>
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-blob</artifactId>
-      <version>12.10.0</version>
+      <version>12.14.1</version>
     </dependency>
   </dependencies>
 

--- a/libraries/bot-dialogs/pom.xml
+++ b/libraries/bot-dialogs/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-blob</artifactId>
-      <version>12.10.0</version>
+      <version>12.14.1</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Fixes #minor

## Description
Component Governance: WS-2020-0408, severity high
https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/5646752?typeId=4354877

"An issue was found in all versions of io.netty:netty-all. Host verification in Netty is disabled by default. This can lead to MITM attack in which an attacker can forge valid SSL/TLS certificates for a different hostname in order to intercept traffic that doesn?t intend for him. This is an issue because the certificate is not matched with the host."

"A specific remediation has not been provided for this vulnerability."

Our netty-handler dependencies come through dependencies on azure-storage-queue and azure-storage-blob.
Alan Zimmer of Azure SDK team says "older versions are safe from the Component Governance warning mentioned below but upgrading will bring fixes for other dependency CVEs and improved performance."

I am upgrading our dependencies for the reason Alan Zimmer gave above.

## Specific Changes
Upgrade Azure dependencies to the October releases.
