### PR TITLE
fix flaky serialization test

### DIFF
--- a/libraries/bot-connector/pom.xml
+++ b/libraries/bot-connector/pom.xml
@@ -53,6 +53,11 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.0</version>
+    </dependency>
 
     <!-- to support ms rest consumption -->
     <dependency>

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/restclient/AdditionalPropertiesSerializerTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/restclient/AdditionalPropertiesSerializerTests.java
@@ -11,11 +11,21 @@ import com.microsoft.bot.restclient.util.Foo;
 import com.microsoft.bot.restclient.util.FooChild;
 import org.junit.Assert;
 import org.junit.Test;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class AdditionalPropertiesSerializerTests {
+    public void assertJsonEqualsNonStrict(String json1, String json2) {
+        try {
+            JSONAssert.assertEquals(json1, json2, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
+
     @Test
     public void canSerializeAdditionalProperties() throws Exception {
         Foo foo = new Foo();
@@ -34,7 +44,8 @@ public class AdditionalPropertiesSerializerTests {
         foo.additionalProperties.put("properties.bar", "barbar");
 
         String serialized = new JacksonAdapter().serialize(foo);
-        Assert.assertEquals("{\"$type\":\"foo\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"hello\":\"world\",\"a.b\":\"c.d\",\"bar.b\":\"uuzz\",\"bar.a\":\"ttyy\"}}}},\"bar\":\"baz\",\"a.b\":\"c.d\",\"properties.bar\":\"barbar\"}", serialized);
+        String expected = "{\"$type\":\"foo\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"hello\":\"world\",\"a.b\":\"c.d\",\"bar.b\":\"uuzz\",\"bar.a\":\"ttyy\"}}}},\"bar\":\"baz\",\"a.b\":\"c.d\",\"properties.bar\":\"barbar\"}";
+        assertJsonEqualsNonStrict(expected, serialized);
     }
 
     @Test
@@ -65,7 +76,8 @@ public class AdditionalPropertiesSerializerTests {
         foo.additionalProperties.put("properties.bar", "barbar");
 
         String serialized = new JacksonAdapter().serialize(foo);
-        Assert.assertEquals("{\"$type\":\"foochild\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"hello\":\"world\",\"a.b\":\"c.d\",\"bar.b\":\"uuzz\",\"bar.a\":\"ttyy\"}}}},\"bar\":\"baz\",\"a.b\":\"c.d\",\"properties.bar\":\"barbar\"}", serialized);
+        String expected = "{\"$type\":\"foochild\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"hello\":\"world\",\"a.b\":\"c.d\",\"bar.b\":\"uuzz\",\"bar.a\":\"ttyy\"}}}},\"bar\":\"baz\",\"a.b\":\"c.d\",\"properties.bar\":\"barbar\"}";
+        assertJsonEqualsNonStrict(expected, serialized);
     }
 
     @Test

--- a/libraries/bot-connector/src/test/java/com/microsoft/bot/restclient/FlatteningSerializerTests.java
+++ b/libraries/bot-connector/src/test/java/com/microsoft/bot/restclient/FlatteningSerializerTests.java
@@ -13,6 +13,8 @@ import com.microsoft.bot.restclient.serializer.JsonFlatten;
 import com.microsoft.bot.restclient.util.Foo;
 import org.junit.Assert;
 import org.junit.Test;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -23,6 +25,14 @@ import java.util.List;
 import java.util.Map;
 
 public class FlatteningSerializerTests {
+    public void assertJsonEqualsNonStrict(String json1, String json2) {
+        try {
+            JSONAssert.assertEquals(json1, json2, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }   
+    }
+
     @Test
     public void canFlatten() throws Exception {
         Foo foo = new Foo();
@@ -40,7 +50,8 @@ public class FlatteningSerializerTests {
 
         // serialization
         String serialized = adapter.serialize(foo);
-        Assert.assertEquals("{\"$type\":\"foo\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"hello\":\"world\",\"a.b\":\"c.d\",\"bar.b\":\"uuzz\",\"bar.a\":\"ttyy\"}}}}}", serialized);
+        String expected = "{\"$type\":\"foo\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"hello\":\"world\",\"a.b\":\"c.d\",\"bar.b\":\"uuzz\",\"bar.a\":\"ttyy\"}}}}}";
+        assertJsonEqualsNonStrict(expected, serialized);
 
         // deserialization
         Foo deserialized = adapter.deserialize(serialized, Foo.class);
@@ -56,7 +67,8 @@ public class FlatteningSerializerTests {
     @Test
     public void canSerializeMapKeysWithDotAndSlash() throws Exception {
         String serialized = new JacksonAdapter().serialize(prepareSchoolModel());
-        Assert.assertEquals("{\"teacher\":{\"students\":{\"af.B/D\":{},\"af.B/C\":{}}},\"tags\":{\"foo.aa\":\"bar\",\"x.y\":\"zz\"},\"properties\":{\"name\":\"school1\"}}", serialized);
+        String expected = "{\"teacher\":{\"students\":{\"af.B/D\":{},\"af.B/C\":{}}},\"tags\":{\"foo.aa\":\"bar\",\"x.y\":\"zz\"},\"properties\":{\"name\":\"school1\"}}";
+        assertJsonEqualsNonStrict(expected, serialized);
     }
 
     /**


### PR DESCRIPTION
## Description
In these four tests, when testing the serialization, originally it compares the serialized String with the expected String. But the order of serialized field is non-deterministic and is, therefore, a flaky test. It might fail when the order does not match, but with the correct output. 

## Specific Changes
- Add JSON assert library
- Write a helper function to compare JSON objects without strict order comparison
- Compare serialized String by JSON assert helper

#minor