### PR TITLE
Update to pick up correct SDK version

### DIFF
--- a/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTests.java
+++ b/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTests.java
@@ -803,7 +803,7 @@ public class QnAMakerTests {
                 results[0].getAnswer());
 
             // Verify that we added the bot.builder package details.
-            Assert.assertTrue(request.getHeader("User-Agent").contains("BotBuilder/4.0.0"));
+            Assert.assertTrue(request.getHeader("User-Agent").contains("BotBuilder/4."));
         } catch (Exception ex) {
             fail();
         } finally {

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/ConnectorConfiguration.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/ConnectorConfiguration.java
@@ -19,7 +19,7 @@ public class ConnectorConfiguration {
     /**
      * Load and pass properties to a function.
      *
-     * @param func T he function to process the loaded properties.
+     * @param func The function to process the loaded properties.
      */
     public void process(Consumer<Properties> func) {
         final Properties properties = new Properties();

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/ConnectorConfiguration.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/ConnectorConfiguration.java
@@ -13,19 +13,18 @@ import java.util.function.Consumer;
 /**
  * Loads configuration properties for bot-connector.
  *
- * Properties are located in an optional connector.properties file in the
- * classpath.
+ * The version of the package will be in the project.properties file.
  */
 public class ConnectorConfiguration {
     /**
      * Load and pass properties to a function.
-     * 
-     * @param func The function to process the loaded properties.
+     *
+     * @param func T he function to process the loaded properties.
      */
     public void process(Consumer<Properties> func) {
         final Properties properties = new Properties();
         try (InputStream propStream =
-            UserAgent.class.getClassLoader().getResourceAsStream("connector.properties")) {
+            UserAgent.class.getClassLoader().getResourceAsStream("project.properties")) {
 
             properties.load(propStream);
             if (!properties.containsKey("version")) {


### PR DESCRIPTION
Fixes #1403 

## Description
Update to pick up correct SDK version and add it to the UserAgent string for metrics collection.

## Specific Changes
Updated to get the version property from the project.properties file instead of the connector.properties file which isn't available.

## Testing
Unit tests were run to validate that desired value was being returned from modified code.