### PR TITLE
Update spring-core and spring-boot packages.

### DIFF
--- a/libraries/bot-integration-spring/pom.xml
+++ b/libraries/bot-integration-spring/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.3.9</version>
+      <version>5.3.14</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
-      <version>2.4.9</version>
+      <version>2.6.2</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Fixes #1407 
## Description
Updated spring-core and spring-boot to latest packages.

## Specific Changes
Updated pom.xml for bot-spring-integration project to 5.3.14 for spring-core and 2.6.2 for spring-boot.

## Testing
Unit tests were executed and passed. EchoBot and Welcome-User samples were built with these changes and executed to validate that they still started up and executed as expected.