### PR TITLE
Additional Security Updates

### DIFF
--- a/libraries/bot-ai-luis-v3/pom.xml
+++ b/libraries/bot-ai-luis-v3/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-ai-qna/pom.xml
+++ b/libraries/bot-ai-qna/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTests.java
+++ b/libraries/bot-ai-qna/src/test/java/com/microsoft/bot/ai/qna/QnAMakerTests.java
@@ -803,7 +803,7 @@ public class QnAMakerTests {
                 results[0].getAnswer());
 
             // Verify that we added the bot.builder package details.
-            Assert.assertTrue(request.getHeader("User-Agent").contains("BotBuilder/4.0.0"));
+            Assert.assertTrue(request.getHeader("User-Agent").contains("BotBuilder/4."));
         } catch (Exception ex) {
             fail();
         } finally {

--- a/libraries/bot-applicationinsights/pom.xml
+++ b/libraries/bot-applicationinsights/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-azure/pom.xml
+++ b/libraries/bot-azure/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-builder/pom.xml
+++ b/libraries/bot-builder/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-connector/pom.xml
+++ b/libraries/bot-connector/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/ConnectorConfiguration.java
+++ b/libraries/bot-connector/src/main/java/com/microsoft/bot/connector/ConnectorConfiguration.java
@@ -13,19 +13,18 @@ import java.util.function.Consumer;
 /**
  * Loads configuration properties for bot-connector.
  *
- * Properties are located in an optional connector.properties file in the
- * classpath.
+ * The version of the package will be in the project.properties file.
  */
 public class ConnectorConfiguration {
     /**
      * Load and pass properties to a function.
-     * 
+     *
      * @param func The function to process the loaded properties.
      */
     public void process(Consumer<Properties> func) {
         final Properties properties = new Properties();
         try (InputStream propStream =
-            UserAgent.class.getClassLoader().getResourceAsStream("connector.properties")) {
+            UserAgent.class.getClassLoader().getResourceAsStream("project.properties")) {
 
             properties.load(propStream);
             if (!properties.containsKey("version")) {

--- a/libraries/bot-dialogs/pom.xml
+++ b/libraries/bot-dialogs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-integration-core/pom.xml
+++ b/libraries/bot-integration-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-integration-spring/pom.xml
+++ b/libraries/bot-integration-spring/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.3.1</version>
+      <version>5.3.14</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
-      <version>2.4.0</version>
+      <version>2.6.2</version>
       <scope>compile</scope>
     </dependency>
 

--- a/libraries/bot-integration-spring/pom.xml
+++ b/libraries/bot-integration-spring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libraries/bot-schema/pom.xml
+++ b/libraries/bot-schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.bot</groupId>
     <artifactId>bot-java</artifactId>
-    <version>4.14.1</version>
+    <version>4.14.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.17.1</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.17.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.microsoft.bot</groupId>
   <artifactId>bot-java</artifactId>
-  <version>4.14.1</version>
+  <version>4.14.2</version>
   <packaging>pom</packaging>
 
   <name>Microsoft BotBuilder Java SDK Parent</name>


### PR DESCRIPTION
#minor

Additional security updates for log4j consisting of the following updates:

Update log4j to version 2.17.1.
Update spring-core to version 5.3.14
Update spring-boot to version 2.6.2
Minor fix for #1404 to put correct SDK version in UserAgent string.
