### PR TITLE
Update Dialog.java

### DIFF
--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/Dialog.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/Dialog.java
@@ -323,7 +323,8 @@ public abstract class Dialog {
         dialogSet.add(dialog);
 
         return dialogSet.createContext(turnContext)
-                .thenAccept(dialogContext -> innerRun(turnContext, dialog.getId(), dialogContext, null));
+                .thenCompose(dialogContext -> innerRun(turnContext, dialog.getId(), dialogContext, null))
+                .thenAccept(dummy -> {});
     }
 
     /**

--- a/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/Dialog.java
+++ b/libraries/bot-dialogs/src/main/java/com/microsoft/bot/dialogs/Dialog.java
@@ -324,7 +324,8 @@ public abstract class Dialog {
 
         return dialogSet.createContext(turnContext)
                 .thenCompose(dialogContext -> innerRun(turnContext, dialog.getId(), dialogContext, null))
-                .thenAccept(dummy -> {});
+                .thenAccept(dummy -> {
+                });
     }
 
     /**


### PR DESCRIPTION
Fixes issue 1428.

Fixes #1428 

## Description
Ensure that an exception returned by `innerRun` is not lost in `run`.

## Specific Changes
Basically replaced thenAccept by thenCompose.

## Testing
N/A