### PR TITLE
Ignore fields to avoid duplicating values when serializing

### DIFF
--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
@@ -1641,6 +1641,7 @@ public class Activity {
      *
      * @return True if the Activity was originate from a streaming connection.
      */
+    @JsonIgnore
     public Boolean isFromStreamingConnection() {
         if (serviceUrl != null) {
             Boolean isHttp = this.getServiceUrl().toLowerCase().startsWith("http");
@@ -1739,6 +1740,7 @@ public class Activity {
      *
      * @return true if the activity is from microsoft teams.
      */
+    @JsonIgnore
     public boolean isTeamsActivity() {
         return "msteams".equals(channelId);
     }


### PR DESCRIPTION
## Description
When deserializing an `Activity` , `teamsActivity` and `fromStreamingConnection` are created due to the method name.

If we then serialize and deserialize it again we will end up with two properties named `teamsActivity` and  `fromStreamingConnection`. This can created a few issues because it will have duplicate keys so it's no longer a valid `JSON`.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Added `@JsonIgnore` to the `isFromStreamingConnection` and `isTeamsActivity` methods

## Testing
```
        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
        Activity activity1 = new Activity();
        String json1 = mapper.writeValueAsString(activity1);
        Activity activity2 = mapper.readValue(json1, Activity.class);
        String json2 = mapper.writeValueAsString(activity2);
```