### PR TITLE
Make the milliseconds in date format optional (#1502)

### DIFF
--- a/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
+++ b/libraries/bot-schema/src/main/java/com/microsoft/bot/schema/Activity.java
@@ -47,7 +47,7 @@ public class Activity {
 
     @JsonProperty(value = "timestamp")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.nXXX", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss[.n]XXX", timezone = "UTC")
     private OffsetDateTime timestamp;
 
     @JsonProperty(value = "localTimestamp")


### PR DESCRIPTION
Fixes #1502

## Description
Make the milliseconds in date format optional

## Specific Changes
- Make the milliseconds in date format optional for timestamp filed in Activity object

## Testing
N/A